### PR TITLE
Nix Documentation and Updates

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -27,9 +27,10 @@ Contrubtions are welcome, so feel free to submit a PR.
    :maxdepth: 3
    :numbered:
    :caption: Contents:
- 
+
    overview.rst
    installation.rst
+   nix.rst
    calculators.rst
    min_optimization.rst
    es_optimization.rst
@@ -38,7 +39,7 @@ Contrubtions are welcome, so feel free to submit a PR.
    irc.rst
    plotting.rst
    pysistrj.rst
-	
+
 Indices and tables
 ==================
 

--- a/docs/nix.rst
+++ b/docs/nix.rst
@@ -1,14 +1,14 @@
 Nix
 ***
 
-The easiest way to get a complete pysisyphus installation is to use the `nix package manager`_.
+The easiest way to get a complete pysisyphus installation with quantum chemistry dependencies is to use the `nix package manager`_.
 A nix installation of pysisyphus comes with "batteries included" and contains the required quantum chemistry programs, provided by the NixWithChemistry_ overlay.
 A nix installation avoids the problems of global installations and virtual environments, is portable and fully reproducible.
 
 Prerequisites
 =============
 
-Nix needs to be installed on your system and working. Follow the installation instructions in the nix manual and possibly the additional hints from NixWithChemistry_.
+Nix needs to be installed on your system and working. Follow the installation instructions in the `nix manual`_ and possibly the additional hints from NixWithChemistry_.
 
 Configuration
 =============
@@ -30,10 +30,10 @@ Clone the code from github, initialise the NixWithChemistry_ submodule and make 
 In :code:`config.nix` make sure to have the following set correctly:
     - :code:`gaussian`, :code:`mrcc`, :code:`orca` and :code:`turbomole` should be set to :code:`false` if no license and source/binary archive is available.
     - The CPU extensions available on your machine should be set correctly. You can check your machine with :code:`grep "flags" /proc/cpuinfo`.
-    - If you are not using CUDA enabled hardware, set :code:`cuda = false;`
-    - :code:`network` should be changed if pysisyphus is going to run on a HPC cluster, where you could change :code:`cuda = "ethernet"` to :code:`cuda = "omnipath"` or :code:`cuda = "infiniband"`. If you are running on local machine keep :code:`cuda = "ethernet"`.
+    - If you are not using CUDA enabled hardware, set :code:`cuda = false;`.
+    - :code:`network` should be changed if pysisyphus is going to run on a HPC cluster, where you could change :code:`network = "ethernet"` to :code:`network = "omnipath"` or :code:`cuda = "infiniband"`. If you are running on local machine keep :code:`cuda = "ethernet"`.
     - :code:`mpi` is set to :code:`"mvapich2"` by default. There  is usually no reason to change this but you could also use :code:`"openmpi"`. This does **not** mean that the selected MPI version will be used in all programs. MRCC requires IntelMPI and GAMESS-US OpenMPI, no matter what you select there.
-    - :code:`blas` can be set to :code:`"mkl"` or :code:`"openblas"`. On Intel CPUs MKL we more efficient, otherwise you should use OpenBLAS.
+    - :code:`blas` can be set to :code:`"mkl"` or :code:`"openblas"`. On Intel CPUs MKL is more efficient, otherwise you should use OpenBLAS.
 
 
 Installation
@@ -57,10 +57,17 @@ You can now make pysisyphus available to your user environment by
 
 or launch a `nix-shell`_ with pysisyphus available by
 
-.. code-block:: basg
+.. code-block:: bash
 
    nix-shell --pure
+
+or use :code:`nix run`
+
+.. code-block:: bash
+
+    nix run
 
 .. _`nix package manager`: https://nixos.org/download.html
 .. _NixWithChemistry: https://gitlab.com/theoretical-chemistry-jena/nixwithchemistry
 .. _`nix-shell`: https://nixos.org/nix/manual/#sec-nix-shell
+.. _`nix manual`: https://nixos.org/manual/nix/stable/

--- a/docs/nix.rst
+++ b/docs/nix.rst
@@ -1,0 +1,66 @@
+Nix
+***
+
+The easiest way to get a complete pysisyphus installation is to use the `nix package manager`_.
+A nix installation of pysisyphus comes with "batteries included" and contains the required quantum chemistry programs, provided by the NixWithChemistry_ overlay.
+A nix installation avoids the problems of global installations and virtual environments, is portable and fully reproducible.
+
+Prerequisites
+=============
+
+Nix needs to be installed on your system and working. Follow the installation instructions in the nix manual and possibly the additional hints from NixWithChemistry_.
+
+Configuration
+=============
+
+Quantum chemistry software is a performance critical part of pysisyphus, might depend on your hardware configuration and its availability might depend on licenses.
+Therefore a small amount of configuration work is necessary for the software from the NixWithChemistry_ repository.
+
+Clone the code from github, initialise the NixWithChemistry_ submodule and make changes to the configuration.
+
+.. code-block:: bash
+
+    git clone https://github.com/eljost/pysisyphus.git $install_dir
+    cd $install_dir
+    git submodule init nix/nixwithchemistry
+    git submodule update
+    # Make changes to the configuration file.
+    edit nix/nixwithchemistry/config.nix
+
+In :code:`config.nix` make sure to have the following set correctly:
+    - :code:`gaussian`, :code:`mrcc`, :code:`orca` and :code:`turbomole` should be set to :code:`false` if no license and source/binary archive is available.
+    - The CPU extensions available on your machine should be set correctly. You can check your machine with :code:`grep "flags" /proc/cpuinfo`.
+    - If you are not using CUDA enabled hardware, set :code:`cuda = false;`
+    - :code:`network` should be changed if pysisyphus is going to run on a HPC cluster, where you could change :code:`cuda = "ethernet"` to :code:`cuda = "omnipath"` or :code:`cuda = "infiniband"`. If you are running on local machine keep :code:`cuda = "ethernet"`.
+    - :code:`mpi` is set to :code:`"mvapich2"` by default. There  is usually no reason to change this but you could also use :code:`"openmpi"`. This does **not** mean that the selected MPI version will be used in all programs. MRCC requires IntelMPI and GAMESS-US OpenMPI, no matter what you select there.
+    - :code:`blas` can be set to :code:`"mkl"` or :code:`"openblas"`. On Intel CPUs MKL we more efficient, otherwise you should use OpenBLAS.
+
+
+Installation
+============
+
+After you made the changes to :code:`nix/nixwithchemistry/config.nix`, you are ready to build.
+
+.. code-block:: bash
+
+    cd $install_dir/nix
+    nix-build
+
+Likely you will depend on closed source software, which is not redistributable.
+If the binary/source archives of these programs are missing from the nix-store, the installation process will interrupt and will tell you how to add the necessary files to the nix-store.
+
+You can now make pysisyphus available to your user environment by
+
+.. code-block:: bash
+
+    nix-env -f default.nix -i
+
+or launch a `nix-shell`_ with pysisyphus available by
+
+.. code-block:: basg
+
+   nix-shell --pure
+
+.. _`nix package manager`: https://nixos.org/download.html
+.. _NixWithChemistry: https://gitlab.com/theoretical-chemistry-jena/nixwithchemistry
+.. _`nix-shell`: https://nixos.org/nix/manual/#sec-nix-shell

--- a/docs/nix.rst
+++ b/docs/nix.rst
@@ -67,6 +67,10 @@ or use :code:`nix run`
 
     nix run
 
+**WARNING** In case of :code:`nix run` the resulting shell will not be pure. Depending on your system configuration conda/pip/... packages and configurations from the system might leak in. You are definitely safe with :code:`nix-shell --pure`.
+
+Do not be confused if the commands of the underlying quantum chemistry codes are not available. They are made available to pysisyphus directly but not necessarily to your shell.
+
 .. _`nix package manager`: https://nixos.org/download.html
 .. _NixWithChemistry: https://gitlab.com/theoretical-chemistry-jena/nixwithchemistry
 .. _`nix-shell`: https://nixos.org/nix/manual/#sec-nix-shell

--- a/nix/default.nix
+++ b/nix/default.nix
@@ -1,6 +1,6 @@
 let nixpkgs = import ./nixpkgs.nix;
     config = import ./nixwithchemistry/config.nix;
-in  with nixpkgs; python37Packages.callPackage ./pysisyphus.nix {
+in  with nixpkgs; python3Packages.callPackage ./pysisyphus.nix {
       orca = if config.orca then orca else null;
       turbomole = if config.turbomole then turbomole else null;
       gaussian = if config.gaussian then gaussian else null;

--- a/nix/nixpkgs.nix
+++ b/nix/nixpkgs.nix
@@ -2,9 +2,9 @@ let
   # nixos-20.03 at 21.07.2020
   nixpkgs = import (builtins.fetchGit {
     url = "https://github.com/nixos/nixpkgs-channels/";
-    name = "nixos-20.03-9ea61f7";
-    rev = "9ea61f7bc4454734ffbff73c9b6173420fe3147b";
-    ref = "refs/heads/nixos-20.03";
+    name = "nixos-20.09";
+    rev = "a9226f2b3a52fcbbc5587d2fa030729e714f40fe";
+    ref = "refs/heads/nixos-20.09";
   }) { overlays = [NixWithChemistry]; };
 
   NixWithChemistry = import ./nixwithchemistry/default.nix;

--- a/nix/pysisyphus.nix
+++ b/nix/pysisyphus.nix
@@ -119,12 +119,27 @@ in
 
     doCheck = false;
 
+    binSearchPath = lib.makeSearchPath "bin" ([ ]
+      ++ lib.optional (orca != null) orca
+      ++ lib.optional (turbomole != null) turbomole
+      ++ lib.optional (gaussian != null) gaussian
+      ++ lib.optional (jmol != null) jmol
+      ++ lib.optional (multiwfn != null) multiwfn
+      ++ lib.optional (xtb != null) xtb
+      ++ lib.optional (openmolcas != null) openmolcas
+      ++ lib.optional (pyscf != null) pyscf
+      ++ lib.optional (psi4 != null) psi4
+      ++ lib.optional (mopac != null) mopac
+      ++ lib.optional (wfoverlap != null) wfoverlap
+    );
+
     postInstall = ''
       mkdir -p $out/share/pysisyphus
       cp ${pysisrc} $out/share/pysisyphus/pysisrc
 
       for exe in $out/bin/*; do
         wrapProgram $exe \
+          --prefix PATH : ${binSearchPath} \
           --set-default "PYSISRC" "$out/share/pysisyphus/pysisrc"
       done;
     '';

--- a/nix/pysisyphus.nix
+++ b/nix/pysisyphus.nix
@@ -13,6 +13,7 @@
 , rmsd
 , scipy
 , sympy
+, bash
 , orca ? orca # or null
 , turbomole ? turbomole # or null
 , gaussian ? gaussian # or null
@@ -27,6 +28,7 @@
 }:
 let
   psi4Wrapper = writeScript "psi4.sh" ''
+    #!${bash}/bin/bash
     ${psi4}/bin/psi4 -o stdout $1
   '';
   pysisrc =


### PR DESCRIPTION
This is the addition of documentation for the nix build in pysisyphus. Furthermore i have updated the NixWithChemistry submodule to include fixes for Multiwfn. 

Potentially we could also add Multiwfn, Jmol, ... if you tell me what you need there and how Pysis is looking for those. The dependencies i currently supply to the pysisyphus build can be found in the first lines of `nix/pysisyphus.nix`. 

The documentation should hopefully contain enough information to build and test everything.
I am currently waiting for my own build to finish to test a few things.