### PR TITLE
buildPythonApplication -> buildPythonPackage

### DIFF
--- a/nix/pysisyphus.nix
+++ b/nix/pysisyphus.nix
@@ -1,4 +1,4 @@
-{ fetchFromGitHub, buildPythonApplication, lib, writeTextFile, writeScript, makeWrapper
+{ fetchFromGitHub, buildPythonPackage, lib, writeTextFile, writeScript, makeWrapper
 # Python dependencies
 , autograd
 , dask
@@ -111,7 +111,7 @@ let
   };
 
 in
-  buildPythonApplication rec {
+  buildPythonPackage rec {
     inherit pname version;
 
     nativeBuildInputs = [


### PR DESCRIPTION
This is a very simple change: It switches the build style to a python library, so that within nix Pysisyphus can also be imported as Python module. With `buildPythonApplication` it can only be run as an executable.