### PR TITLE
Static Nix

### DIFF
--- a/docs/nix.rst
+++ b/docs/nix.rst
@@ -83,7 +83,7 @@ These archives can be build using
 
 .. code-block:: bash
 
-  ./nix/bundle.sh
+  cd nix && ./bundle.sh
 
 and come by default with the open source quantum chemistry codes. If others are required, you may point the :code:`PYSISRC` environment variable to a pysisyphus rc, where e.g. Gaussian is configured.
 

--- a/docs/nix.rst
+++ b/docs/nix.rst
@@ -74,8 +74,22 @@ from within the pysisyphus repository.
 
 Do not be confused if the commands of the underlying quantum chemistry codes are not available. They are made available to directly to the pysisyphus entry point, but not necessarily to your shell.
 
+Static Pysisyphus
+=================
+
+Using `Nix Bundle`, it is possible to obtain fully self-contained archives, that run independent of Nix and the linux distribution.
+
+These archives can be build using
+
+.. code-block:: bash
+
+  ./nix/bundle.sh
+
+and come by default with the open source quantum chemistry codes. If others are required, you may point the :code:`PYSISRC` environment variable to a pysisyphus rc, where e.g. Gaussian is configured.
+
 .. _`Nix package manager`: https://nixos.org/download.html
 .. _`NixOS-QChem`: https://github.com/markuskowa/NixOS-QChem
 .. _`nix-shell`: https://nixos.org/nix/manual/#sec-nix-shell
 .. _`nix manual`: https://nixos.org/manual/nix/stable/
 .. _`Nix Pills`: https://nixos.org/guides/nix-pills/index.html
+.. _`Nix Bundle`: https://github.com/matthewbauer/nix-bundle

--- a/nix/bundle.sh
+++ b/nix/bundle.sh
@@ -5,4 +5,5 @@ export NIX_PATH=nixpkgs=https://github.com/NixOS/nixpkgs/archive/71326cd12ddfa0f
 
 for i in pysis pysisfilter pysispack pysisplot pysisthermo pysistrj; do
   nix-bundle '(import ./default.nix { })' /bin/$i > $i
+  chmod +x $i
 done

--- a/nix/bundle.sh
+++ b/nix/bundle.sh
@@ -1,0 +1,8 @@
+#! /usr/bin/env nix-shell
+#! nix-shell -i bash -p nix-bundle -I nixpkgs=https://github.com/NixOS/nixpkgs/archive/71326cd12ddfa0fac40fdb451fcba7dad763c56e.tar.gz
+
+export NIX_PATH=nixpkgs=https://github.com/NixOS/nixpkgs/archive/71326cd12ddfa0fac40fdb451fcba7dad763c56e.tar.gz
+
+for i in pysis pysisfilter pysispack pysisplot pysisthermo pysistrj; do
+  nix-bundle '(import ./default.nix { })' /bin/$i > $i
+done

--- a/nix/default.nix
+++ b/nix/default.nix
@@ -13,9 +13,10 @@ in with pkgs; qchem.python3.pkgs.callPackage ./pysisyphus.nix {
   inherit fullTest;
 
   # Uncomment below to enable optional engines.
-  orca = qchem.orca;
-  turbomole = qchem.turbomole;
-  cfour = qchem.cfour;
-  molpro = qchem.molpro;
-  gaussian = qchem.gaussian;
+  # orca = qchem.orca;
+  orca = null; # Uses the screenreader if not given
+  # turbomole = qchem.turbomole;
+  # cfour = qchem.cfour;
+  # molpro = qchem.molpro;
+  # gaussian = qchem.gaussian;
 }

--- a/nix/pysisyphus.nix
+++ b/nix/pysisyphus.nix
@@ -3,7 +3,8 @@
  autograd, dask, distributed, h5py, jinja2, matplotlib, numpy, natsort, pytest, pyyaml, rmsd, scipy,
  sympy, scikitlearn, qcengine, ase, xtb-python, openbabel-bindings,
  # Runtime dependencies
- runtimeShell, jmol, multiwfn, xtb, openmolcas, pyscf, psi4, wfoverlap, nwchem, orca ? null ,
+ runtimeShell, jmol ? null, multiwfn ? null, xtb ? null, openmolcas ? null,
+ pyscf ? null, psi4 ? null, wfoverlap ? null, nwchem ? null, orca ? null,
  turbomole ? null, gaussian ? null, gamess-us ? null, cfour ? null, molpro ? null,
  # Test dependencies
  openssh,
@@ -22,14 +23,14 @@ let
         formchk_cmd = "${gaussian}/bin/formchk";
         unfchk_cmd = "${gaussian}/bin/unfchk";
       };
-      text = with lib.lists; lib.generators.toINI {} (builtins.listToAttrs ([
-        { name = "openmolcas"; value.cmd = "${openmolcas}/bin/pymolcas"; }
-        { name = "psi4"; value.cmd = "${psi4Wrapper}"; }
-        { name = "wfoverlap"; value.cmd = "${wfoverlap}/bin/wfoverlap.x"; }
-        { name = "multiwfn"; value.cmd = "${multiwfn}/bin/Multiwfn"; }
-        { name = "jmol"; value.cmd = "${jmol}/bin/jmol"; }
-        { name = "xtb"; value.cmd = "${xtb}/bin/xtb"; }
-      ] ++ optional (gaussian != null) { name = "gaussian16"; value = gaussian16Conf; }
+      text = with lib.lists; lib.generators.toINI {} (builtins.listToAttrs ([ ]
+        ++ optional (openmolcas != null) { name = "openmolcas"; value.cmd = "${openmolcas}/bin/pymolcas"; }
+        ++ optional (psi4 != null) { name = "psi4"; value.cmd = "${psi4Wrapper}"; }
+        ++ optional (wfoverlap != null) { name = "wfoverlap"; value.cmd = "${wfoverlap}/bin/wfoverlap.x"; }
+        ++ optional (multiwfn != null) { name = "multiwfn"; value.cmd = "${multiwfn}/bin/Multiwfn"; }
+        ++ optional (jmol != null) { name = "jmol"; value.cmd = "${jmol}/bin/jmol"; }
+        ++ optional (xtb != null) { name = "xtb"; value.cmd = "${xtb}/bin/xtb"; }
+        ++ optional (gaussian != null) { name = "gaussian16"; value = gaussian16Conf; }
         ++ optional (orca != null) { name = "orca"; value.cmd = "${orca}/bin/orca"; }
       ));
     in
@@ -38,16 +39,16 @@ let
         name = "pysisrc";
       };
 
-  binSearchPath = with lib; makeSearchPath "bin" ([
-    jmol
-    multiwfn
-    xtb
-    openmolcas
-    pyscf
-    psi4
-    wfoverlap
-    nwchem
-  ] ++ lists.optional (orca != null) orca
+  binSearchPath = with lib; makeSearchPath "bin" ([ ]
+    ++ lists.optional (jmol != null) jmol
+    ++ lists.optional (multiwfn != null) multiwfn
+    ++ lists.optional (xtb != null) xtb
+    ++ lists.optional (openmolcas != null) openmolcas
+    ++ lists.optional (pyscf != null) pyscf
+    ++ lists.optional (psi4 != null) psi4
+    ++ lists.optional (wfoverlap != null) wfoverlap
+    ++ lists.optional (nwchem != null) nwchem
+    ++ lists.optional (orca != null) orca
     ++ lists.optional (turbomole != null) turbomole
     ++ lists.optional (gaussian != null) gaussian
     ++ lists.optional (cfour != null) cfour
@@ -77,19 +78,20 @@ in
       scikitlearn
       qcengine
       ase
-      xtb-python
       openbabel-bindings
-      pytest # Also required for normal execution
-      # Syscalls
-      jmol
-      multiwfn
-      xtb
-      openmolcas
-      pyscf
-      psi4
-      wfoverlap
-      nwchem
-    ] ++ lists.optional (orca != null) orca
+      pytest  # Also required for normal execution
+      openssh
+    ] # Syscalls
+      ++ lists.optional (xtb-python != null) xtb-python
+      ++ lists.optional (jmol != null) jmol
+      ++ lists.optional (multiwfn != null) multiwfn
+      ++ lists.optional (xtb != null) xtb
+      ++ lists.optional (openmolcas != null) openmolcas
+      ++ lists.optional (pyscf != null) pyscf
+      ++ lists.optional (psi4 != null) psi4
+      ++ lists.optional (wfoverlap != null) wfoverlap
+      ++ lists.optional (nwchem != null) nwchem
+      ++ lists.optional (orca != null) orca
       ++ lists.optional (turbomole != null) turbomole
       ++ lists.optional (gaussian != null) gaussian
       ++ lists.optional (cfour != null) cfour
@@ -98,7 +100,8 @@ in
 
     src = lib.cleanSource ../.;
 
-    doCheck = true;
+    # Requires at least PySCF
+    doCheck = pyscf != null;
 
     checkInputs = [ pytest openssh ];
 
@@ -113,7 +116,8 @@ in
       }
     '';
 
-    postInstall = ''
+    postInstall = if lib.lists.all (x: x == null) [ gaussian openmolcas orca psi4 xtb multiwfn jmol ]
+      then "" else ''
       mkdir -p $out/share/pysisyphus
       cp ${pysisrc} $out/share/pysisyphus/pysisrc
       for exe in $out/bin/*; do

--- a/nix/sources.json
+++ b/nix/sources.json
@@ -5,10 +5,10 @@
         "homepage": null,
         "owner": "markuskowa",
         "repo": "NixOS-QChem",
-        "rev": "786f6c3e8ff89c29b3b43668f926d292b8bb79dd",
-        "sha256": "1ahn9qgbgjhcbhrgi128vrlb78j0lx8hqiiq74wd2qvrqq4mmzsn",
+        "rev": "60c2629828b867a88cc0069d23f431d1ae68a5d9",
+        "sha256": "15z53j8ad3zybwpnxrfq8lj2h6xyrb61r25i80w4dxid87m2h8wk",
         "type": "tarball",
-        "url": "https://github.com/markuskowa/NixOS-QChem/archive/786f6c3e8ff89c29b3b43668f926d292b8bb79dd.tar.gz",
+        "url": "https://github.com/markuskowa/NixOS-QChem/archive/60c2629828b867a88cc0069d23f431d1ae68a5d9.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "nixpkgs": {
@@ -17,10 +17,10 @@
         "homepage": "",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "840f6883fc5b445038fc6d170b38b42658fca1c8",
-        "sha256": "1kczq26ifx0kniza300vlj4lz28qh53qqkbqs9siss4kp8qrghln",
+        "rev": "db6e089456cdddcd7e2c1d8dac37a505c797e8fa",
+        "sha256": "02yk20i9n5nhn6zgll3af7kp3q5flgrpg1h5vcqfdqcck8iikx4b",
         "type": "tarball",
-        "url": "https://github.com/NixOS/nixpkgs/archive/840f6883fc5b445038fc6d170b38b42658fca1c8.tar.gz",
+        "url": "https://github.com/NixOS/nixpkgs/archive/db6e089456cdddcd7e2c1d8dac37a505c797e8fa.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     }
 }


### PR DESCRIPTION
Makes all QC drivers optional and adds docs and toolings for building directly distributable pysisyphus executables, containing the open source quantum chemistry engines.

```bash
cd nix && ./bundle.sh
```
will generate executable archives of all pysisyphus entry point executables.