### PR TITLE
Nix Updates: XTB-Python, CI

### DIFF
--- a/.github/workflows/pythonapp.yml
+++ b/.github/workflows/pythonapp.yml
@@ -20,45 +20,10 @@ on:
 jobs:
   build:
 
-    runs-on: ubuntu-latest
-
+    runs-on: nixos
     steps:
     - uses: actions/checkout@v2
-    - uses: actions/cache@v1
-      with:
-        path: ~/.cache/pip
-        key: ${{ runner.os }}-pip-
-    - name: Set up Python 3.8
-      uses: actions/setup-python@v1
-      with:
-        python-version: 3.8
-    - name: Install dependencies
+    - name: Nix Build
       run: |
-        python -m pip install --upgrade pip
-        pip install -e .
-    - name: Lint with flake8
-      run: |
-        pip install flake8
-        # stop the build if there are Python syntax errors or undefined names
-        flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
-        # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
-        flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
-    - name: Install ASE
-      run: |
-        pip install ase>=3.21.1
-    - name: Install pyscf
-      run: |
-        pip install pyscf==1.7.5.1
-    - name: Install thermoanalysis
-      run: |
-        pip install git+https://github.com/eljost/thermoanalysis.git
-    - name: Test with pytest
-      run: |
-        pip install pytest pytest-cov
-        pytest -v --cov=pysisyphus --cov-config .coveragerc --cov-report xml --cov-report term tests --show-capture=no  --durations=0
-    - name: Upload coverage to codecov
-      uses: codecov/codecov-action@v1
-      with:
-        token: ${{ secrets.CODECOV_TOKEN }}
-        file: ./coverage.xml
-        flags: unittests
+        cd nix
+        nix-build --arg fullTest false

--- a/.github/workflows/pythonapp.yml
+++ b/.github/workflows/pythonapp.yml
@@ -20,10 +20,45 @@ on:
 jobs:
   build:
 
-    runs-on: nixos
+    runs-on: ubuntu-latest
+
     steps:
     - uses: actions/checkout@v2
-    - name: Nix Build
+    - uses: actions/cache@v1
+      with:
+        path: ~/.cache/pip
+        key: ${{ runner.os }}-pip-
+    - name: Set up Python 3.8
+      uses: actions/setup-python@v1
+      with:
+        python-version: 3.8
+    - name: Install dependencies
       run: |
-        cd nix
-        nix-build --arg fullTest false
+        python -m pip install --upgrade pip
+        pip install -e .
+    - name: Lint with flake8
+      run: |
+        pip install flake8
+        # stop the build if there are Python syntax errors or undefined names
+        flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
+        # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
+        flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
+    - name: Install ASE
+      run: |
+        pip install ase>=3.21.1
+    - name: Install pyscf
+      run: |
+        pip install pyscf==1.7.5.1
+    - name: Install thermoanalysis
+      run: |
+        pip install git+https://github.com/eljost/thermoanalysis.git
+    - name: Test with pytest
+      run: |
+        pip install pytest pytest-cov
+        pytest -v --cov=pysisyphus --cov-config .coveragerc --cov-report xml --cov-report term tests --show-capture=no  --durations=0
+    - name: Upload coverage to codecov
+      uses: codecov/codecov-action@v1
+      with:
+        token: ${{ secrets.CODECOV_TOKEN }}
+        file: ./coverage.xml
+        flags: unittests

--- a/nix/default.nix
+++ b/nix/default.nix
@@ -4,19 +4,8 @@
 
 let pkgs = import ./pkgs.nix { inherit postOverlays; };
 in with pkgs; qchem.python3.pkgs.callPackage ./pysisyphus.nix {
-  multiwfn = qchem.multiwfn;
-  xtb = qchem.xtb;
-  wfoverlap = qchem.wfoverlap;
-  nwchem = qchem.nwchem;
+  orca = qchem.orca; # Uses the screenreader if not given
 
   # Perform full testing?
   inherit fullTest;
-
-  # Uncomment below to enable optional engines.
-  # orca = qchem.orca;
-  orca = null; # Uses the screenreader if not given
-  # turbomole = qchem.turbomole;
-  # cfour = qchem.cfour;
-  # molpro = qchem.molpro;
-  # gaussian = qchem.gaussian;
 }

--- a/nix/pkgs.nix
+++ b/nix/pkgs.nix
@@ -9,7 +9,8 @@ let
 
     # See https://github.com/markuskowa/NixOS-QChem#configuration-via-nixpkgs
     qchem-config = {
-      optAVX = true;
+      optAVX = false;
+      optArch = "x86-64";
       useCuda = false;
     };
   };

--- a/nix/pkgs.nix
+++ b/nix/pkgs.nix
@@ -10,7 +10,7 @@ let
     # See https://github.com/markuskowa/NixOS-QChem#configuration-via-nixpkgs
     qchem-config = {
       optAVX = false;
-      optArch = "x86-64";
+      optArch = null;
       useCuda = false;
     };
   };

--- a/nix/pysisyphus.nix
+++ b/nix/pysisyphus.nix
@@ -1,7 +1,7 @@
 { fetchPypi, fetchFromGitHub, buildPythonPackage, lib, writeTextFile, writeScript, makeWrapper,
  # Python dependencies
  autograd, dask, distributed, h5py, jinja2, matplotlib, numpy, natsort, pytest, pyyaml, rmsd, scipy,
- sympy, scikitlearn, qcengine, ase, xtb-python, openbabel-bindings,
+ sympy, scikit-learn, qcengine, ase, xtb-python, openbabel-bindings,
  # Runtime dependencies
  runtimeShell, jmol ? null, multiwfn ? null, xtb ? null, openmolcas ? null,
  pyscf ? null, psi4 ? null, wfoverlap ? null, nwchem ? null, orca ? null,
@@ -58,7 +58,7 @@ let
 in
   buildPythonPackage rec {
     pname = "pysisyphus";
-    version = "0.7.post1";
+    version = "0.7.2";
 
     nativeBuildInputs = [ makeWrapper ];
 
@@ -75,7 +75,7 @@ in
       rmsd
       scipy
       sympy
-      scikitlearn
+      scikit-learn
       qcengine
       ase
       openbabel-bindings

--- a/nix/release.nix
+++ b/nix/release.nix
@@ -1,0 +1,5 @@
+{
+  pysisyphusWrapped = import ./default.nix {
+    fullTest = true;
+  };
+}

--- a/nix/sources.json
+++ b/nix/sources.json
@@ -5,10 +5,10 @@
         "homepage": null,
         "owner": "markuskowa",
         "repo": "NixOS-QChem",
-        "rev": "ba0033b2a87982d6b299943d16dab0d85eff9a96",
-        "sha256": "1gnfp4f7kn1ip1wipxv5kc4c1scv19hbq0m7rhhhhlxyafmny15j",
+        "rev": "e50900356b82862bf7f8da019601655f9fd0a2d6",
+        "sha256": "0gqpddi8vqhzhxb4jzvb4r80r05vgxi9vibgyxdnv1c11ry31x5c",
         "type": "tarball",
-        "url": "https://github.com/markuskowa/NixOS-QChem/archive/ba0033b2a87982d6b299943d16dab0d85eff9a96.tar.gz",
+        "url": "https://github.com/markuskowa/NixOS-QChem/archive/e50900356b82862bf7f8da019601655f9fd0a2d6.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "nixpkgs": {
@@ -17,10 +17,10 @@
         "homepage": "",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "fc3de6da83863f8f36fdcac1c199c6066a6a0378",
-        "sha256": "0wdy7x46im6ddmy2m671a89mlrcc61nvp9v21vl60w8g040prxfs",
+        "rev": "bca7162d606e7b5fd1d1fe9324fed5d645624c5c",
+        "sha256": "1xzn496fxa6iascfkid4lsglm5qrd9biyz11ldy8akkx98br44df",
         "type": "tarball",
-        "url": "https://github.com/NixOS/nixpkgs/archive/fc3de6da83863f8f36fdcac1c199c6066a6a0378.tar.gz",
+        "url": "https://github.com/NixOS/nixpkgs/archive/bca7162d606e7b5fd1d1fe9324fed5d645624c5c.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     }
 }

--- a/nix/sources.json
+++ b/nix/sources.json
@@ -5,10 +5,10 @@
         "homepage": null,
         "owner": "markuskowa",
         "repo": "NixOS-QChem",
-        "rev": "60c2629828b867a88cc0069d23f431d1ae68a5d9",
-        "sha256": "15z53j8ad3zybwpnxrfq8lj2h6xyrb61r25i80w4dxid87m2h8wk",
+        "rev": "ba0033b2a87982d6b299943d16dab0d85eff9a96",
+        "sha256": "1gnfp4f7kn1ip1wipxv5kc4c1scv19hbq0m7rhhhhlxyafmny15j",
         "type": "tarball",
-        "url": "https://github.com/markuskowa/NixOS-QChem/archive/60c2629828b867a88cc0069d23f431d1ae68a5d9.tar.gz",
+        "url": "https://github.com/markuskowa/NixOS-QChem/archive/ba0033b2a87982d6b299943d16dab0d85eff9a96.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "nixpkgs": {
@@ -17,10 +17,10 @@
         "homepage": "",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "db6e089456cdddcd7e2c1d8dac37a505c797e8fa",
-        "sha256": "02yk20i9n5nhn6zgll3af7kp3q5flgrpg1h5vcqfdqcck8iikx4b",
+        "rev": "fc3de6da83863f8f36fdcac1c199c6066a6a0378",
+        "sha256": "0wdy7x46im6ddmy2m671a89mlrcc61nvp9v21vl60w8g040prxfs",
         "type": "tarball",
-        "url": "https://github.com/NixOS/nixpkgs/archive/db6e089456cdddcd7e2c1d8dac37a505c797e8fa.tar.gz",
+        "url": "https://github.com/NixOS/nixpkgs/archive/fc3de6da83863f8f36fdcac1c199c6066a6a0378.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     }
 }

--- a/nix/sources.json
+++ b/nix/sources.json
@@ -5,10 +5,10 @@
         "homepage": null,
         "owner": "markuskowa",
         "repo": "NixOS-QChem",
-        "rev": "e50900356b82862bf7f8da019601655f9fd0a2d6",
-        "sha256": "0gqpddi8vqhzhxb4jzvb4r80r05vgxi9vibgyxdnv1c11ry31x5c",
+        "rev": "6a237a671766a8b5fd131b94bc47673b9930a7b8",
+        "sha256": "1y4z02311hfdkz1cj9rkmayldzry2zpm07zbahpqgs50a7lk6d6h",
         "type": "tarball",
-        "url": "https://github.com/markuskowa/NixOS-QChem/archive/e50900356b82862bf7f8da019601655f9fd0a2d6.tar.gz",
+        "url": "https://github.com/markuskowa/NixOS-QChem/archive/6a237a671766a8b5fd131b94bc47673b9930a7b8.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "nixpkgs": {
@@ -17,10 +17,10 @@
         "homepage": "",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "bca7162d606e7b5fd1d1fe9324fed5d645624c5c",
-        "sha256": "1xzn496fxa6iascfkid4lsglm5qrd9biyz11ldy8akkx98br44df",
+        "rev": "2bb5cbf7f8b99a8d1d6646abe5ab993f6823212f",
+        "sha256": "0vn6znlk36azpha4jinvwg6mqqhzahm4m3lfy86p4drb7rb72w8i",
         "type": "tarball",
-        "url": "https://github.com/NixOS/nixpkgs/archive/bca7162d606e7b5fd1d1fe9324fed5d645624c5c.tar.gz",
+        "url": "https://github.com/NixOS/nixpkgs/archive/2bb5cbf7f8b99a8d1d6646abe5ab993f6823212f.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     }
 }

--- a/setup.py
+++ b/setup.py
@@ -42,7 +42,7 @@ setup(
         "rmsd",
         "scipy>=1.4.1",
         "sympy>=1.5.1",
-        "scikit-learn>=0.24.2",
+        "scikit-learn>=0.24.1",
     ],
     # Install locally with
     #   pip install -e .[extra]


### PR DESCRIPTION
Updates of the Nix infrastructure. NixOS-QChem includes an update to Psi4 (1.3.2 -> 1.4), XTB-Python (XTBPATH always set now) and more package updates.

Attempts to have a CI running with Nix.