### PR TITLE
nix: add gamess-us interface, update deps, update docs and caching

### DIFF
--- a/docs/nix.rst
+++ b/docs/nix.rst
@@ -20,16 +20,31 @@ Please follow the installation instructions in the `nix manual`_ to set up a wor
 Configuration
 =============
 
-Typically no, or only very few, adjustements are necessary.
+Typically no, or only very few, adjustments are necessary.
+In :code:`nix/pkgs.nix` the following options can be changed:
 
 - :code:`optAVX` can be used to enable/disable AVX tunings in underlying quantum chemistry packages.
-- :code:`licMolpro` can be set to a molpro license token to enable the Molpro package.
 - :code:`optpath` can be set and point to the top-level installation directory of a Gaussian installation.
+
+The :code:`postOverlays` attribute can be used to further customise the underlying package sets, i.e. switching to MKL as a BLAS/LAPACK implementation.
+See the comments in code:`nix/pkgs.nix`.
+
+Additional, proprietary quantum chemistry codes can be enabled by uncommenting the :code:`enable*` lines in `nix/default.nix`.
 
 For more details on the configuration options see the NixOS-QChem_ repository.
 
-The :code:`postOverlays` attribute can be used to further customise the underlying package sets.
+Caching
+=======
 
+The build time can be reduced drastically, if the quantum chemistry codes are fetched from a binary cache.
+
+NixOS-QChem_ overlay provides a binary cache on Cachix.
+
+If you are allowed to add binary cache in nix, you may simply execute:
+
+.. code-block:: bash
+
+    nix-shell -p cachix --run "cachix use nix-qchem"
 
 Installation
 ============
@@ -48,9 +63,7 @@ and build the nix-derivation
 
     cd pysisyphus/nix
     # Executing nix-build for the first time may take a while as your local Nix store
-    # will be populated.
-    # Please grab a coffee while the command runs or start your own coffee plantation
-    # and return after you picked your first crop of coffee berries ☕.
+    # will be populated. Caching can speed this up.
     nix-build
 
 You will likely depend on closed source software (ORCA, Turbomole, Gaussian, ...) , which is not freely redistributable. If the binary/source archives of these programs are missing from the Nix-store, the installation process will interrupt and tell you how to provide the required files. So it's a good idea to investigate the output of `nix-build` from time to time check, if manual intervention is required.
@@ -73,19 +86,6 @@ or launch a interactive `nix-shell`_ with pysisyphus by
 from within the pysisyphus repository.
 
 Do not be confused if the commands of the underlying quantum chemistry codes are not available. They are made available to directly to the pysisyphus entry point, but not necessarily to your shell.
-
-Static Pysisyphus
-=================
-
-Using `Nix Bundle`, it is possible to obtain fully self-contained archives, that run independent of Nix and the linux distribution.
-
-These archives can be build using
-
-.. code-block:: bash
-
-  cd nix && ./bundle.sh
-
-and come by default with the open source quantum chemistry codes. If others are required, you may point the :code:`PYSISRC` environment variable to a pysisyphus rc, where e.g. Gaussian is configured.
 
 .. _`Nix package manager`: https://nixos.org/download.html
 .. _`NixOS-QChem`: https://github.com/markuskowa/NixOS-QChem

--- a/nix/bundle.sh
+++ b/nix/bundle.sh
@@ -1,9 +1,0 @@
-#! /usr/bin/env nix-shell
-#! nix-shell -i bash -p nix-bundle -I nixpkgs=https://github.com/NixOS/nixpkgs/archive/71326cd12ddfa0fac40fdb451fcba7dad763c56e.tar.gz
-
-export NIX_PATH=nixpkgs=https://github.com/NixOS/nixpkgs/archive/71326cd12ddfa0fac40fdb451fcba7dad763c56e.tar.gz
-
-for i in pysis pysisfilter pysispack pysisplot pysisthermo pysistrj; do
-  nix-bundle '(import ./default.nix { })' /bin/$i > $i
-  chmod +x $i
-done

--- a/nix/default.nix
+++ b/nix/default.nix
@@ -1,9 +1,23 @@
-{ fullTest ? false
-, postOverlays ? []
-} :
+let pkgs = import ./pkgs.nix;
 
-let pkgs = import ./pkgs.nix { inherit postOverlays; };
 in with pkgs; qchem.python3.pkgs.callPackage ./pysisyphus.nix {
+  # Enable quantum chemistry codes by setting them to true.
+  # The default settings in ./pysisyphus.nix enable only free codes
+  #enableJmol = true;
+  #enableMultiwfn = true;
+  #enableXtb = true;
+  #enableOpenmolcas = true;
+  #enablePsi4 = true;
+  #enableWfoverlap = true;
+  #enableNwchem = true;
+  #enableOrca = true;
+  #enableTurbomole = true;
+  #enableGaussian = true;
+  #enableCfour = true;
+  #enableMolpro = true;
+  #enableGamess = true;
+
+  # Usually no need to change.
   multiwfn = qchem.multiwfn;
   xtb = qchem.xtb;
   openmolcas = qchem.molcas;
@@ -15,7 +29,5 @@ in with pkgs; qchem.python3.pkgs.callPackage ./pysisyphus.nix {
   gaussian = qchem.gaussian;
   cfour = qchem.cfour;
   molpro = qchem.molpro;
-
-  # Perform full testing?
-  inherit fullTest;
+  gamess-us = qchem.gamess-us.override { enableMpi = false; };
 }

--- a/nix/pkgs.nix
+++ b/nix/pkgs.nix
@@ -1,16 +1,19 @@
-{ postOverlays ? [] } :
-
 let
   sources = import ./sources.nix;
   qchemOverlay = import sources.NixOS-QChem;
+  postOverlay = self: super:
+    { # Example to change MPI/BLAS+LAPACK providers. Uncomment to switch to MKL and MVAPICH, i.e.
+      /*
+      blas = super.blas.override { blasProvider = super.mkl; };
+      lapack = super.lapack.override { lapackProvider = super.mkl; };
+      mpi = super.mvapich;
+      */
+    };
   nixpkgs = import sources.nixpkgs {
-    overlays = [ qchemOverlay ] ++ postOverlays;
-    allowUnfree = true;
-
-    # See https://github.com/markuskowa/NixOS-QChem#configuration-via-nixpkgs
+    overlays = [ qchemOverlay postOverlay ];
+    allowUnfree = false; # Change to true if you want to use proprietary software
     qchem-config = {
-      optAVX = false;
-      optArch = null;
+      optAVX = false; # Change to true if your CPU supports at least AVX2 (Haswell upwards)
       useCuda = false;
     };
   };

--- a/nix/release.nix
+++ b/nix/release.nix
@@ -1,5 +1,3 @@
 {
-  pysisyphusWrapped = import ./default.nix {
-    fullTest = true;
-  };
+  pysisyphusWrapped = (import ./default.nix).override { fullTest = true; };
 }

--- a/nix/shell.nix
+++ b/nix/shell.nix
@@ -1,13 +1,7 @@
-{ fullTest ? false
-, postOverlays ? []
-} :
-
 let
-  pkgs = import ./pkgs.nix { inherit postOverlays; };
+  pkgs = import ./pkgs.nix;
   pysis = { pysisyphus = import ./default.nix { inherit fullTest; }; };
   allPkgs = pkgs // pysis;
-in
-  with allPkgs;
-  mkShell {
-    buildInputs = [ pysisyphus ];
-  }
+in with allPkgs; mkShell {
+  buildInputs = [ python3.pkgs.qcengine qchem.gamess-us ];
+}

--- a/nix/sources.json
+++ b/nix/sources.json
@@ -5,10 +5,10 @@
         "homepage": null,
         "owner": "markuskowa",
         "repo": "NixOS-QChem",
-        "rev": "3abdd090e6c652496ea415a9b599ed083e1c773c",
-        "sha256": "0w2n90cwjzbz2qnwh2wg8h02nsykcv21cl5spajyii69qhhv2zk7",
+        "rev": "9650ce599d05da30ba1c16077d9cfc28594b71ff",
+        "sha256": "0g4vxr23kmy7lilwwivaxvadapdxmrd2xdfn24qbh467is4pg824",
         "type": "tarball",
-        "url": "https://github.com/markuskowa/NixOS-QChem/archive/3abdd090e6c652496ea415a9b599ed083e1c773c.tar.gz",
+        "url": "https://github.com/markuskowa/NixOS-QChem/archive/9650ce599d05da30ba1c16077d9cfc28594b71ff.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "nixpkgs": {
@@ -17,10 +17,10 @@
         "homepage": "",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "f096b7122ab08e93c8b052c92461ca71b80c0cc8",
-        "sha256": "00k0072wi46afspy3d2xfh12x1z68jbxay4s5x6cp03b5r4rdp6j",
+        "rev": "b05d2077ebe219f6a47825767f8bab5c6211d200",
+        "sha256": "02jvk5rh05qbsgf2qffd6vw9w0z9n3kablgi1ff2a794s9rc8q4s",
         "type": "tarball",
-        "url": "https://github.com/NixOS/nixpkgs/archive/f096b7122ab08e93c8b052c92461ca71b80c0cc8.tar.gz",
+        "url": "https://github.com/NixOS/nixpkgs/archive/b05d2077ebe219f6a47825767f8bab5c6211d200.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     }
 }

--- a/nix/sources.json
+++ b/nix/sources.json
@@ -5,10 +5,10 @@
         "homepage": null,
         "owner": "markuskowa",
         "repo": "NixOS-QChem",
-        "rev": "9650ce599d05da30ba1c16077d9cfc28594b71ff",
-        "sha256": "0g4vxr23kmy7lilwwivaxvadapdxmrd2xdfn24qbh467is4pg824",
+        "rev": "b9c65da4525a979e58154a231c305d5e34ecef3f",
+        "sha256": "1n8v5zwhf97r5z6irsrzv782mxi0qg6f5afa117mvf15p18hdald",
         "type": "tarball",
-        "url": "https://github.com/markuskowa/NixOS-QChem/archive/9650ce599d05da30ba1c16077d9cfc28594b71ff.tar.gz",
+        "url": "https://github.com/markuskowa/NixOS-QChem/archive/b9c65da4525a979e58154a231c305d5e34ecef3f.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "nixpkgs": {
@@ -17,10 +17,10 @@
         "homepage": "",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "b05d2077ebe219f6a47825767f8bab5c6211d200",
-        "sha256": "02jvk5rh05qbsgf2qffd6vw9w0z9n3kablgi1ff2a794s9rc8q4s",
+        "rev": "5efc8ca954272c4376ac929f4c5ffefcc20551d5",
+        "sha256": "15xncc1afq8v78acrcv8xbfkd3ii147mv9a55823pdbqffzg0x54",
         "type": "tarball",
-        "url": "https://github.com/NixOS/nixpkgs/archive/b05d2077ebe219f6a47825767f8bab5c6211d200.tar.gz",
+        "url": "https://github.com/NixOS/nixpkgs/archive/5efc8ca954272c4376ac929f4c5ffefcc20551d5.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     }
 }


### PR DESCRIPTION
Updates to the Nix infrastructure. Changes:

- the default version builds only with free (and thus cachable) packages by default
- redundancies in nix function calls have been removed
- added a section on caching has been added to the docs. Cachix provides cached builds for all open-source packages, thus the build should be very fast now
- removed the bundle option, proved to be to unreliable
- updates to external dependencies
- an option for gamess-us has been added