### PR TITLE
Fix nix-shell

### DIFF
--- a/nix/shell.nix
+++ b/nix/shell.nix
@@ -1,8 +1,12 @@
 let pkgs = import ./pkgs.nix;
+    pysisyphus = pkgs.python3.pkgs.pysisyphus.overrideAttrs (_: {
+      doCheck = false;
+      doInstallCheck = false;
+    });
 in with pkgs; mkShell {
-  buildInputs = [ python3.pkgs.pysisyphus ]
-    ++ python3.pkgs.pysisyphus.nativeBuildInputs
-    ++ python3.pkgs.pysisyphus.buildInputs
-    ++ python3.pkgs.pysisyphus.propagatedBuildInputs
+  buildInputs = [pysisyphus ]
+    ++ pysisyphus.nativeBuildInputs
+    ++ pysisyphus.buildInputs
+    ++ pysisyphus.propagatedBuildInputs
   ;
 }

--- a/nix/sources.json
+++ b/nix/sources.json
@@ -5,10 +5,10 @@
         "homepage": null,
         "owner": "markuskowa",
         "repo": "NixOS-QChem",
-        "rev": "d9c72e7b6c1f63c2a67fc28e94450d0b41e7e793",
-        "sha256": "01ypxxb7vcgzfdccyq9h46r9xwawx1qcc501qqjx647ynynhly2w",
+        "rev": "d1f5da50211678c7a7d8544bbc7ae9bea02ffb63",
+        "sha256": "1qc279282znifk5vpaq5pwqb4fjzj3xb2zbdwzcnvy8dbywzihdj",
         "type": "tarball",
-        "url": "https://github.com/markuskowa/NixOS-QChem/archive/d9c72e7b6c1f63c2a67fc28e94450d0b41e7e793.tar.gz",
+        "url": "https://github.com/markuskowa/NixOS-QChem/archive/d1f5da50211678c7a7d8544bbc7ae9bea02ffb63.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "nixpkgs": {


### PR DESCRIPTION
The nix-shell did not disable testing. THis is probably not what we want; it makes the evalutation of the nix-shell slow and prohibits entering a dev shell, when a test fails. Has been fixed.