### PR TITLE
Nix CI

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,23 +1,21 @@
 variables:
   GIT_SUBMODULE_STRATEGY: recursive
-  NIXQC_SRCURL: http://kashyyyk:8888/nix-src
-  NIXQC_AVX: 0
-  NIXPKGS_ALLOW_UNFREE: 1
+
+image: nixos/nix:2.7.0-amd64
 
 stages:
   - build
   - test
   - distribute
 
-before_script:
+.before_nix: &before_nix
   - mkdir -p ~/.config/nix
   - echo "experimental-features = nix-command flakes" > ~/.config/nix/nix.conf
-  - nix-env -f ./nix/pkgs.nix -iA bash cachix
+  - nix run .#cachix use pysisyphus
 
 nix build:
   stage: build
-  tags:
-    - nix
+  before_script: *before_nix
   script:
     - |
       nix-build -E "(import ./nix/pkgs.nix).python3.pkgs.pysisyphus.overrideAttrs (oldAttrs: {
@@ -33,8 +31,7 @@ nix build:
 
 nix shell:
   stage: build
-  tags:
-    - nix
+  before_script: *before_nix
   script:
     - nix develop --command echo ""
   after_script:
@@ -46,10 +43,15 @@ nix shell:
 nix test:
   stage: test
   tags:
-    - nix
+    - kashyyyk
     - turbomole
     - orca
     - gamess
+  before_script:
+    - *before_nix
+    - nix store prefetch-file http://kashyyyk:8888/nix-src/turbolinux751.tar.gz
+    - nix store prefetch-file http://kashyyyk:8888/nix-src/orca_5_0_3_linux_x86-64_shared_openmpi411.tar.xz
+    - nix store prefetch-file http://kashyyyk:8888/nix-src/gamess-us-2021R2P1.tar.gz
   script:
     - |
       nix-build -E "(import ./nix/pkgs.nix).python3.pkgs.pysisyphus.override {

--- a/flake.lock
+++ b/flake.lock
@@ -3,11 +3,11 @@
     "flake-compat": {
       "flake": false,
       "locked": {
-        "lastModified": 1641205782,
-        "narHash": "sha256-4jY7RCWUoZ9cKD8co0/4tFARpWB+57+r1bLLvXNJliY=",
+        "lastModified": 1648199409,
+        "narHash": "sha256-JwPKdC2PoVBkG6E+eWw3j6BMR6sL3COpYWfif7RVb8Y=",
         "owner": "edolstra",
         "repo": "flake-compat",
-        "rev": "b7547d3eed6f32d06102ead8991ec52ab0a4f1a7",
+        "rev": "64a525ee38886ab9028e6f61790de0832aa3ef03",
         "type": "github"
       },
       "original": {
@@ -18,11 +18,11 @@
     },
     "flake-utils": {
       "locked": {
-        "lastModified": 1644229661,
-        "narHash": "sha256-1YdnJAsNy69bpcjuoKdOYQX0YxZBiCYZo4Twxerqv7k=",
+        "lastModified": 1649676176,
+        "narHash": "sha256-OWKJratjt2RW151VUlJPRALb7OU2S5s+f0vLj4o1bHM=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "3cecb5b042f7f209c56ffd8371b2711a290ec797",
+        "rev": "a4b154ebbdc88c8498a5c7b01589addc9e9cb678",
         "type": "github"
       },
       "original": {
@@ -33,11 +33,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1647350163,
-        "narHash": "sha256-OcMI+PFEHTONthXuEQNddt16Ml7qGvanL3x8QOl2Aao=",
+        "lastModified": 1649843365,
+        "narHash": "sha256-nm25C0Y3rxE4xkXVdrdX9BP1QABh5VMFOWKvDWpk73o=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "3eb07eeafb52bcbf02ce800f032f18d666a9498d",
+        "rev": "0343e3415784b2cd9c68924294794f7dbee12ab3",
         "type": "github"
       },
       "original": {
@@ -48,11 +48,11 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1646271573,
-        "narHash": "sha256-X0W5eTiYzfgzEKkhYBLaGqA1aodKyledNDcqNx/r+e8=",
+        "lastModified": 1647887150,
+        "narHash": "sha256-1TnRvE3qhhafrQnGapaaSVue6nEwRUICkz227TfHHQw=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "7a3e6d6604ad99c77e7a98943734bdeea564bff2",
+        "rev": "4c3c80df545ec5cb26b5480979c3e3f93518cbe5",
         "type": "github"
       },
       "original": {
@@ -67,11 +67,11 @@
         "nixpkgs": "nixpkgs_2"
       },
       "locked": {
-        "lastModified": 1647005614,
-        "narHash": "sha256-yGWsh2eeWgHVCx+KpSF7Sg5wdiqrARiZGxyKeZhKjck=",
+        "lastModified": 1648822489,
+        "narHash": "sha256-i8antd9ChbrJzSdwhw9A415HIAtGtRAe1rXWB1r9yo0=",
         "owner": "markuskowa",
         "repo": "nixos-qchem",
-        "rev": "b890bbbd4ae9aeb303f00ac7c1579bd80139b925",
+        "rev": "f7835c4132509eb8d8508fa51b67bc3c7493aa13",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Dependency update via flakes. Also changes to standard runners for GitLab, that do not rely on a shared Nix store anymore. This fix is necessary as the concept broke recently, but it is also a good idea anyway, as it makes everything more agnostic with respect to the runner hardware.