### PR TITLE
Flake Substituters

### DIFF
--- a/docs/nix.rst
+++ b/docs/nix.rst
@@ -25,7 +25,9 @@ The build time can be reduced drastically, if the quantum chemistry codes are fe
 
 Pysisyphus provides a binary cache on Cachix.
 
-If you are allowed to add binary cache in nix, you may simply execute:
+Nix >= 2.6.0 with flakes directly supports the binary cache without further action required.
+
+Alternatively, if you are allowed to add binary caches in nix, you may simply execute:
 
 .. code-block:: bash
 

--- a/flake.nix
+++ b/flake.nix
@@ -15,6 +15,12 @@
     flake-utils.url = "github:numtide/flake-utils";
   };
 
+  nixConfig = {
+    # Custom prompt in nix develop shell
+    bash-prompt = ''\[\e[0;1;38;5;215m\]pysisyphus\[\e[0;1m\]:\[\e[0;1;38;5;75m\]\w\[\e[0;1m\]$ \[\e[0m\]'';    
+    subtituters = [ "https://pysisyphus.cachix.org" ];
+  };
+
   outputs = { self, nixpkgs, qchem, flake-utils, ... }:
     flake-utils.lib.eachSystem [ "x86_64-linux" ] (system:
 

--- a/flake.nix
+++ b/flake.nix
@@ -18,7 +18,7 @@
   nixConfig = {
     # Custom prompt in nix develop shell
     bash-prompt = ''\[\e[0;1;38;5;215m\]pysisyphus\[\e[0;1m\]:\[\e[0;1;38;5;75m\]\w\[\e[0;1m\]$ \[\e[0m\]'';    
-    subtituters = [ "https://pysisyphus.cachix.org" ];
+    subtituters = [ "https://pysisyphus.cachix.org" "https://cache.nixos.org" ];
   };
 
   outputs = { self, nixpkgs, qchem, flake-utils, ... }:

--- a/flake.nix
+++ b/flake.nix
@@ -119,6 +119,9 @@
 
         devShell = self.devShells."${system}".default;
 
+        hydraJobs = {
+          pysisyphus = self.packages.x86_64-linux.pysisyphus;
+        };
       }) // {
         overlays.default = import ./nix/overlay.nix;
         overlay = self.overlays.default;


### PR DESCRIPTION
With Nix >= 2.6.0 the underdocumented `nixConfig` attributes was introduced, that conveniently allows unprivileged users to use the cachix binary cache without further action.