### PR TITLE
nix: use extra-substituters instead of substituters

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -18,7 +18,7 @@
   nixConfig = {
     # Custom prompt in nix develop shell
     bash-prompt = ''\[\e[0;1;38;5;215m\]pysisyphus\[\e[0;1m\]:\[\e[0;1;38;5;75m\]\w\[\e[0;1m\]$ \[\e[0m\]'';    
-    subtituters = [ "https://pysisyphus.cachix.org" "https://cache.nixos.org" ];
+    extra-subtituters = [ "https://pysisyphus.cachix.org" ];
   };
 
   outputs = { self, nixpkgs, qchem, flake-utils, ... }:


### PR DESCRIPTION
Addendum to #206 . Now using `extra-substituters` instead of `substituters`, which does not kick out other ones already configured on the system.