### PR TITLE
Add DFT-D3 as an external potential

### DIFF
--- a/docs/calculators.rst
+++ b/docs/calculators.rst
@@ -282,6 +282,35 @@ RMSD
     :members:
     :undoc-members:
 
+DFT-D3
+----
+Method to add DFT-D3 dispersion corrections as an external potential
+via the program developed by the Grimme group <https://www.chemie.uni-bonn.de/grimme/de/software/dft-d3/get_dft-d3>.
+
+This is for use with calculators that do not natively provide D3 corrections (e.g. OpenMolcas).
+Usage mirrors that of other external potentials, with an example given below.
+
+.. code:: yaml
+    
+    # General input structure for restraints
+    calc:
+     type: ext
+     # Multiple potentials could be specified here as a list
+     potentials:
+       # Add atom-pairwise D3 dispersion correction as a differentiable, external potential
+       - type: d3
+         # Functional is specified in TURBOMOLE format, all lower case.
+         functional: pbe
+         # Optional Becke-Johnson damping, default false, recommended true
+         bjdamping: true
+
+    calc:
+     type: [actual calculator that is wrapped by ExternalPotential]
+
+.. automodule:: pysisyphus.calculators.DFTD3
+    :members:
+    :undoc-members:
+
 AFIR
 ----
 .. automodule:: pysisyphus.calculators.AFIR

--- a/pysisyphus/calculators/DFTD3.py
+++ b/pysisyphus/calculators/DFTD3.py
@@ -1,14 +1,16 @@
-from pysisyphus.calculators.Calculator import Calculator
 import re
+
 import numpy as np
-import os.path
+
+from pysisyphus.calculators.Calculator import Calculator
+
 
 class DFTD3(Calculator):
     
     conf_key = "dftd3"
 
     def __init__(self, geom, functional, bjdamping=False, **kwargs):
-        super(DFTD3, self).__init__(**kwargs)
+        super().__init__(**kwargs)
         self.atoms = geom.atoms
         self.functional = functional.lower()
         self.bjdamping = bjdamping
@@ -28,7 +30,7 @@ class DFTD3(Calculator):
         return results
 
     def parse_gradient(self, path):
-        grad = np.loadtxt(os.path.join(path,"dftd3_gradient"))
+        grad = np.loadtxt(path / "dftd3_gradient")
         energy = self.parse_energy(path)["energy"]
         results={
             "energy": energy,

--- a/pysisyphus/calculators/DFTD3.py
+++ b/pysisyphus/calculators/DFTD3.py
@@ -1,0 +1,64 @@
+from pysisyphus.calculators.Calculator import Calculator
+import re
+import numpy as np
+import os.path
+
+class DFTD3(Calculator):
+    
+    conf_key = "dftd3"
+
+    def __init__(self, atoms, functional, bjdamping=False, **kwargs):
+        super(DFTD3, self).__init__(**kwargs)
+        self.atoms = atoms
+        self.functional = functional.lower()
+        self.bjdamping = bjdamping
+
+        self.parser_funcs = {
+            "energy": self.parse_energy,
+            "grad": self.parse_gradient,
+        }
+
+    def parse_energy(self, path):
+        with open(path / self.out_fn) as handle:
+            text = handle.read()
+        mobj = re.search(r"Edisp /kcal,au:\s+([\d\-\.]+)\s+([\d\-\.]+)", text)
+        results={
+            "energy": float(mobj[-1]),
+        }
+        return results
+
+    def parse_gradient(self, path):
+        grad = np.loadtxt(os.path.join(path,"dftd3_gradient"))
+        energy = self.parse_energy(path)
+        results={
+            "energy": energy,
+            "grad": grad.flatten(),
+        }
+        return results
+  
+    def calc(self, coords3d, gradient=False):
+        inp = self.prepare_turbo_coords(self.atoms, coords3d.flatten())
+        
+        args = [f"-func {self.functional}"]
+        if self.bjdamping:
+            args.append("-bj")
+        if gradient:
+            args.append("-grad")
+        
+        if gradient:
+            calc_type = "grad"
+        else:
+            calc_type = "energy"
+
+        results = self.run(inp, calc=calc_type, cmd="dftd3", add_args=args)
+        
+        if not gradient:
+            return results["energy"]
+        else:
+            return results["energy"], results["grad"] 
+    
+    def __str__(self):
+        return f"DFT-D3({self.name})"
+
+
+

--- a/pysisyphus/calculators/DFTD3.py
+++ b/pysisyphus/calculators/DFTD3.py
@@ -7,9 +7,9 @@ class DFTD3(Calculator):
     
     conf_key = "dftd3"
 
-    def __init__(self, atoms, functional, bjdamping=False, **kwargs):
+    def __init__(self, geom, functional, bjdamping=False, **kwargs):
         super(DFTD3, self).__init__(**kwargs)
-        self.atoms = atoms
+        self.atoms = geom.atoms
         self.functional = functional.lower()
         self.bjdamping = bjdamping
 

--- a/pysisyphus/calculators/DFTD3.py
+++ b/pysisyphus/calculators/DFTD3.py
@@ -23,13 +23,13 @@ class DFTD3(Calculator):
             text = handle.read()
         mobj = re.search(r"Edisp /kcal,au:\s+([\d\-\.]+)\s+([\d\-\.]+)", text)
         results={
-            "energy": float(mobj[-1]),
+            "energy": float(mobj.group(2)),
         }
         return results
 
     def parse_gradient(self, path):
         grad = np.loadtxt(os.path.join(path,"dftd3_gradient"))
-        energy = self.parse_energy(path)
+        energy = self.parse_energy(path)["energy"]
         results={
             "energy": energy,
             "grad": grad.flatten(),
@@ -39,7 +39,7 @@ class DFTD3(Calculator):
     def calc(self, coords3d, gradient=False):
         inp = self.prepare_turbo_coords(self.atoms, coords3d.flatten())
         
-        args = [f"-func {self.functional}"]
+        args = ["-func", self.functional]
         if self.bjdamping:
             args.append("-bj")
         if gradient:

--- a/pysisyphus/calculators/ExternalPotential.py
+++ b/pysisyphus/calculators/ExternalPotential.py
@@ -11,7 +11,7 @@ from pysisyphus.intcoords.PrimTypes import prims_from_prim_inputs
 from pysisyphus.intcoords.update import correct_dihedrals
 from pysisyphus.intcoords import Torsion
 from pysisyphus.linalg import rmsd_grad
-
+from pysisyphus.calculators.DFTD3 import DFTD3
 
 class LogFermi:
     def __init__(self, beta, radius, T=300, origin=(0.0, 0.0, 0.0), geom=None):
@@ -200,6 +200,7 @@ class ExternalPotential(Calculator):
         "harmonic_sphere": HarmonicSphere,
         "restraint": Restraint,
         "rmsd": RMSD,
+        "d3": DFTD3,
     }
 
     def __init__(self, calculator=None, potentials=None, geom=None, **kwargs):


### PR DESCRIPTION
Some programs available as a calculator don't have built-in D3/D3(BJ) dispersion corrections (e.g. OpenMolcas). As D3 is a density-independent, atom-pairwise correction that depends only on the molecular geometry, it effectively functions as an additive external potential. This pull request aims to add D3 as an available external potential (even if it leverages the Calculator class for I/O). As implemented, it is assumed that the dftd3 binary is available on $PATH, but the code is freely available under the GPL at https://www.chemie.uni-bonn.de/grimme/de/software/dft-d3/get_dft-d3.