### PR TITLE
nix: update flake

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -18,11 +18,11 @@
     },
     "flake-utils": {
       "locked": {
-        "lastModified": 1667395993,
-        "narHash": "sha256-nuEHfE/LcWyuSWnS8t12N1wc105Qtau+/OdUAjtQ0rA=",
+        "lastModified": 1676283394,
+        "narHash": "sha256-XX2f9c3iySLCw54rJ/CZs+ZK6IQy7GXNY4nSOyu2QG4=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "5aed5285a952e0b949eb3ba02c12fa4fcfef535f",
+        "rev": "3db36a8b464d0c4532ba1c7dda728f4576d6d073",
         "type": "github"
       },
       "original": {
@@ -33,11 +33,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1674778051,
-        "narHash": "sha256-iJ4/HZok9JVSDdl8bYQx2a6Btxna+C/E5Otp0mTXWH0=",
+        "lastModified": 1677142198,
+        "narHash": "sha256-Y/uC2ZmkQkyrdRZ5szZilhZ/46786Wio5CGTgL+Vb/c=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "e62676e855cc300d6a2a76f72c28eaa532aff277",
+        "rev": "03fb72201639e5274fee6d77b0d9c66e98329aba",
         "type": "github"
       },
       "original": {
@@ -53,11 +53,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1674824412,
-        "narHash": "sha256-wjunXk/4pWNif+LSkderZosk8i43SFXF64A35RyriEg=",
+        "lastModified": 1677245864,
+        "narHash": "sha256-vOdesddorcRAP4lsHl9wO92qGX5Zw7WE9hLxrPmG6F0=",
         "owner": "markuskowa",
         "repo": "nixos-qchem",
-        "rev": "5d63355fbcd787a83f512164b5307ba05cf57fd2",
+        "rev": "4e81e42654031e5f968641ddc26bce920818ef17",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Flake update with DFTB+ and the recent XTB 6.6.0 included.