### PR TITLE
Add feature to import custom plugins in Psi4 calculations

### DIFF
--- a/examples/calc/01_psi4_to_set_1/01_psi4_to_set_1.yaml
+++ b/examples/calc/01_psi4_to_set_1/01_psi4_to_set_1.yaml
@@ -18,6 +18,10 @@ calc:
  to_set:
   reference: uhf
   roots_per_irrep: "[1, ]"
+ # All entries here will be printed in the Psi4 input as
+ # import [value]
+ # If the PYTHONPATH is set accordingly, the Psi4 plugin or python package will be imported
+ to_import: [numpy, sys]
  basis: DZ
  charge: 1
  mult: 2

--- a/pysisyphus/calculators/Psi4.py
+++ b/pysisyphus/calculators/Psi4.py
@@ -15,6 +15,7 @@ class Psi4(Calculator):
         method,
         basis,
         to_set=None,
+        to_import=None,
         pcm="iefpcm",
         solvent=None,
         write_fchk=False,
@@ -25,6 +26,7 @@ class Psi4(Calculator):
         self.method = method
         self.basis = basis
         self.to_set = {} if to_set is None else dict(to_set)
+        self.to_import = [] if to_import is None else list(to_import)
         self.pcm = pcm
         self.solvent = solvent
         self.write_fchk = write_fchk
@@ -43,6 +45,7 @@ class Psi4(Calculator):
 
         self.inp = textwrap.dedent(
             """
+        {to_import}
         molecule mol{{
           {xyz}
           {charge} {mult}
@@ -96,6 +99,8 @@ class Psi4(Calculator):
         method += "\nprint('PARSE ENERGY:', wfn.energy())"
         set_strs = [f"set {key} {value}" for key, value in self.to_set.items()]
         set_strs = "\n".join(set_strs)
+        import_strs = [f"import {mod}" for mod in self.to_import]
+        import_strs = "\n".join(import_strs)
 
         # Basis section
         basis = self.basis
@@ -150,6 +155,7 @@ class Psi4(Calculator):
             charge=self.charge,
             mult=self.mult,
             basis=basis,
+            to_import=import_strs,
             to_set=set_strs,
             pcm=pcm,
             method=method,


### PR DESCRIPTION
Dear Pysisyphus Developers,

First of all, I want to express my gratitude for developing and maintaining Pysisyphus. It is a powerful tool to find reaction paths that I've modified to work with my custom Psi4 plugin.

I needed to make small edits to `Psi4.py` which sets up the formatting of the psi4 input files to do this; A user can now provide a list of module names where the calculator class adds an `import [module]` line at the top of each generated Psi4 file. I've mimicked the style of the pre-existing `to_set` data member, and I show an example of its use in `examples/calc/01_psi4_to_set_1/01_psi4_to_set_1.yaml`

This change would be particularly useful for other Psi4 developers that would like to use their own plugins with Pysisyphus. Therefore, I thought it would be a good idea to submit this pull request.

Thank you for considering this addition to Pysisyphus. I'm looking forward to any feedback you might have.

Best regards,
Marcus Liebenthal