### PR TITLE
Nix Updates

### DIFF
--- a/.github/workflows/pythonapp.yml
+++ b/.github/workflows/pythonapp.yml
@@ -21,7 +21,7 @@ jobs:
         with:
           nix_path: nixpkgs=channel:nixpkgs-unstable
           extra_nix_config: access-tokens = github.com=${{ secrets.GITHUB_TOKEN }}
-      - uses: cachix/cachix-action@v12
+      - uses: cachix/cachix-action@v20
         with:
           name: pysisyphus
           authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'

--- a/docs/nix.rst
+++ b/docs/nix.rst
@@ -91,7 +91,7 @@ or build singularity or docker containers:
 
 .. code-block:: bash
 
-    nix build .#pysisyphusSingularity
+    nix bundle --bundler .#toSingularityImage
 
 
 .. _`Nix package manager`: https://nixos.org/download.html

--- a/flake.lock
+++ b/flake.lock
@@ -17,12 +17,15 @@
       }
     },
     "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
       "locked": {
-        "lastModified": 1676283394,
-        "narHash": "sha256-XX2f9c3iySLCw54rJ/CZs+ZK6IQy7GXNY4nSOyu2QG4=",
+        "lastModified": 1685518550,
+        "narHash": "sha256-o2d0KcvaXzTrPRIo0kOLV0/QXHhDQ5DTi+OxcjO8xqY=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "3db36a8b464d0c4532ba1c7dda728f4576d6d073",
+        "rev": "a1720a10a6cfe8234c0e93907ffe81be440f4cef",
         "type": "github"
       },
       "original": {
@@ -31,13 +34,129 @@
         "type": "github"
       }
     },
+    "flake-utils_2": {
+      "locked": {
+        "lastModified": 1623875721,
+        "narHash": "sha256-A8BU7bjS5GirpAUv4QA+QnJ4CceLHkcXdRp4xITDB0s=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "f7e004a55b120c02ecb6219596820fcd32ca8772",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nix-bundle": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      },
+      "locked": {
+        "lastModified": 1626704917,
+        "narHash": "sha256-cJ73kxY5ZCPWQeQZyCSdvkBqjqJkU5wgETBNaXfqF18=",
+        "owner": "matthewbauer",
+        "repo": "nix-bundle",
+        "rev": "223f4ffc4179aa318c34dc873a08cb00090db829",
+        "type": "github"
+      },
+      "original": {
+        "owner": "matthewbauer",
+        "repo": "nix-bundle",
+        "type": "github"
+      }
+    },
+    "nix-utils": {
+      "inputs": {
+        "flake-utils": "flake-utils_2",
+        "nixpkgs": "nixpkgs_2"
+      },
+      "locked": {
+        "lastModified": 1632973430,
+        "narHash": "sha256-9G8zo+0nfYAALV5umCyQR/2hVUFNH10JropBkyxZGGw=",
+        "owner": "juliosueiras-nix",
+        "repo": "nix-utils",
+        "rev": "b44e1ffd726aa03056db9df469efb497d8b9871b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "juliosueiras-nix",
+        "repo": "nix-utils",
+        "type": "github"
+      }
+    },
+    "nixBundlers": {
+      "inputs": {
+        "nix-bundle": "nix-bundle",
+        "nix-utils": "nix-utils",
+        "nixpkgs": "nixpkgs_3"
+      },
+      "locked": {
+        "lastModified": 1672257746,
+        "narHash": "sha256-uVVAUIxGPnNKv0pIhmjxlHZ78dFAlQh4gMNoT2iDJko=",
+        "owner": "NixOS",
+        "repo": "bundlers",
+        "rev": "3476034902f2d1dbf3021acd6d883fb39b217697",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "master",
+        "repo": "bundlers",
+        "type": "github"
+      }
+    },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1677142198,
-        "narHash": "sha256-Y/uC2ZmkQkyrdRZ5szZilhZ/46786Wio5CGTgL+Vb/c=",
+        "lastModified": 1620055814,
+        "narHash": "sha256-8LEHoYSJiL901bTMVatq+rf8y7QtWuZhwwpKE2fyaRY=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "03fb72201639e5274fee6d77b0d9c66e98329aba",
+        "rev": "1db42b7fe3878f3f5f7a4f2dc210772fd080e205",
+        "type": "github"
+      },
+      "original": {
+        "id": "nixpkgs",
+        "ref": "nixos-20.03-small",
+        "type": "indirect"
+      }
+    },
+    "nixpkgs_2": {
+      "locked": {
+        "lastModified": 1629252929,
+        "narHash": "sha256-Aj20gmGBs8TG7pyaQqgbsqAQ6cB+TVuL18Pk3DPBxcQ=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "3788c68def67ca7949e0864c27638d484389363d",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_3": {
+      "locked": {
+        "lastModified": 1634782485,
+        "narHash": "sha256-psfh4OQSokGXG0lpq3zKFbhOo3QfoeudRcaUnwMRkQo=",
+        "path": "/nix/store/p53cz6rh27q40g9i0q98k3vfrz6lm12w-source",
+        "rev": "34ad3ffe08adfca17fcb4e4a47bb5f3b113687be",
+        "type": "path"
+      },
+      "original": {
+        "id": "nixpkgs",
+        "type": "indirect"
+      }
+    },
+    "nixpkgs_4": {
+      "locked": {
+        "lastModified": 1686582075,
+        "narHash": "sha256-vtflsfKkHtF8IduxDNtbme4cojiqvlvjp5QNYhvoHXc=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "7e63eed145566cca98158613f3700515b4009ce3",
         "type": "github"
       },
       "original": {
@@ -53,11 +172,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1677245864,
-        "narHash": "sha256-vOdesddorcRAP4lsHl9wO92qGX5Zw7WE9hLxrPmG6F0=",
+        "lastModified": 1686741526,
+        "narHash": "sha256-1w8o+HXU9ubz1kRYR56g8jHz/dbJuckJGvXIDK4aw1M=",
         "owner": "markuskowa",
         "repo": "nixos-qchem",
-        "rev": "4e81e42654031e5f968641ddc26bce920818ef17",
+        "rev": "2959232611d40f836daa79522c6fb5e96caea295",
         "type": "github"
       },
       "original": {
@@ -71,8 +190,24 @@
       "inputs": {
         "flake-compat": "flake-compat",
         "flake-utils": "flake-utils",
-        "nixpkgs": "nixpkgs",
+        "nixBundlers": "nixBundlers",
+        "nixpkgs": "nixpkgs_4",
         "qchem": "qchem"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
       }
     }
   },

--- a/flake.nix
+++ b/flake.nix
@@ -15,6 +15,8 @@
     };
 
     flake-utils.url = "github:numtide/flake-utils";
+
+    nixBundlers.url = "github:NixOS/bundlers/master";
   };
 
   nixConfig = {
@@ -23,7 +25,7 @@
     extra-subtituters = [ "https://pysisyphus.cachix.org" ];
   };
 
-  outputs = { self, nixpkgs, qchem, flake-utils, ... }:
+  outputs = { self, nixpkgs, qchem, flake-utils, nixBundlers, ... }:
     flake-utils.lib.eachSystem [ "x86_64-linux" ]
       (system:
         let
@@ -38,6 +40,21 @@
               };
             };
           };
+
+          toSingularityImage = drv: pkgs.singularity-tools.buildImage {
+            name = drv.name;
+            contents = with pkgs; [
+              drv
+              bashInteractive
+              coreutils
+              findutils
+              gnused
+              which
+            ];
+            diskSize = 40000;
+            memSize = 2000;
+          };
+
         in
         {
           packages = {
@@ -55,40 +72,6 @@
               enableCfour = true;
               enableMolpro = true;
               enableGamess = true;
-            };
-
-            pysisyphusDocker = pkgs.dockerTools.buildImage {
-              name = self.packages."${system}".pysisyphus.pname;
-              tag = self.packages."${system}".pysisyphus.version;
-
-              fromImageName = null;
-              fromImageTag = null;
-
-              copyToRoot = pkgs.buildEnv {
-                name = "image-root";
-                paths = [
-                  # Necessary for interactive usage
-                  pkgs.bashInteractive
-                  pkgs.coreutils
-
-                  # Computational chemistry software
-                  self.packages."${system}".pysisyphus
-                ];
-                pathsToLink = [ "/bin" ];
-              };
-            };
-
-            pysisyphusSingularity = pkgs.singularity-tools.buildImage {
-              name = self.packages."${system}".pysisyphus.name;
-              contents = with pkgs; [ bashInteractive coreutils self.packages."${system}".pysisyphus ];
-
-              # Size of the virtual disk used for building the container.
-              # This is NOT the final disk size.
-              diskSize = 10000;
-
-              # Memory for the virtualisation environment that BUILDS the image.
-              # This is not a runtime parameter of the image.
-              memSize = 6000;
             };
           };
 
@@ -112,6 +95,14 @@
                 export PYSISRC=${pkgs.python3.pkgs.pysisyphus.passthru.pysisrc}
               '';
             };
+
+          bundlers = {
+            inherit toSingularityImage;
+            inherit (nixBundlers.bundlers."${system}") toArx toDEB toRPM toDockerImage;
+            default = self.bundlers."${system}".toArx;
+          };
+
+          formatter = pkgs.nixpkgs-fmt;
 
         }) // {
       overlays.default = import ./nix/overlay.nix;

--- a/flake.nix
+++ b/flake.nix
@@ -103,8 +103,11 @@
           };
 
           formatter = pkgs.nixpkgs-fmt;
-
         }) // {
       overlays.default = import ./nix/overlay.nix;
+
+      hydraJobs."x86_64-linux" = {
+        inherit (self.packages."x86_64-linux") pysisyphus pysisyphusFull;
+      };
     };
 }

--- a/nix/pysisyphus.nix
+++ b/nix/pysisyphus.nix
@@ -70,7 +70,7 @@ let
 in
   buildPythonPackage rec {
     pname = "pysisyphus";
-    version = "0.7.6post2";
+    version = "0.8.0b0";
 
     nativeBuildInputs = [ makeWrapper setuptools-scm ];
 


### PR DESCRIPTION
Here is another Nix update. The multiwfn build issues should be gone now. Nix-QChem uses our sanitised GitLab mirror of Multiwfn now instead of the unstable link from upstream, that regularly breaks the hash.

Other goodies:

- Psi4 1.8
- New numpy and scipy versions
- PySCF 2.2.1
- Nix bundlers are included now. They are the standardised flake way to build packages for non-Nix systems. Included is a self-extracting, executable archive (Arx), Debian and RPM packages (`sudo apt install pysisyphus` incoming ;) ), Singularity and Docker containers, e.g. `nix bundle --bundler .#toSingularityImage` to get a singularity image file for pysis or `nix bundle --bundler .#toDEB` for debian packages.