### PR TITLE
use popen.communicate to replace popen.wait

### DIFF
--- a/pysisyphus/calculators/Calculator.py
+++ b/pysisyphus/calculators/Calculator.py
@@ -513,7 +513,7 @@ class Calculator:
                     env=env,
                     shell=shell,
                 )
-                result.wait()
+                result.communicate()
                 try:
                     normal_termination = False
                     # Calling check_termination may result in an exception and


### PR DESCRIPTION
popen.wait may cause deadlock, popen.communicate will avoid that. 
ref: https://docs.python.org/3/library/subprocess.html#subprocess.Popen.wait