### PR TITLE
Add CFOUR Calculator support

### DIFF
--- a/docs/calculators.rst
+++ b/docs/calculators.rst
@@ -219,6 +219,13 @@ OpenBabel
     :undoc-members:
     :show-inheritance:
 
+CFOUR
+-------
+.. automodule:: pysisyphus.calculators.CFOUR
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
 
 
 Meta (wrapping) Calculators

--- a/pysisyphus/Geometry.py
+++ b/pysisyphus/Geometry.py
@@ -258,12 +258,12 @@ class Geometry:
         ), f"'freeze_atoms' must all be >= 0 and < {len(self.atoms)}!"
 
         # Disallow any coord_kwargs with coord_type == 'cart'
-        # if (coord_type == "cart") and not (coord_kwargs is None or coord_kwargs == {}):
-        #     print(
-        #         "coord_type is set to 'cart' but coord_kwargs were given. "
-        #         "This is probably not intended. Exiting!"
-        #     )
-        #     sys.exit()
+        if (coord_type == "cart") and not (coord_kwargs is None or coord_kwargs == {}):
+            print(
+                "coord_type is set to 'cart' but coord_kwargs were given. "
+                "This is probably not intended. Exiting!"
+            )
+            sys.exit()
 
         # Coordinate systems are handled below
         coord_class = self.coord_types[self.coord_type]

--- a/pysisyphus/Geometry.py
+++ b/pysisyphus/Geometry.py
@@ -258,12 +258,12 @@ class Geometry:
         ), f"'freeze_atoms' must all be >= 0 and < {len(self.atoms)}!"
 
         # Disallow any coord_kwargs with coord_type == 'cart'
-        if (coord_type == "cart") and not (coord_kwargs is None or coord_kwargs == {}):
-            print(
-                "coord_type is set to 'cart' but coord_kwargs were given. "
-                "This is probably not intended. Exiting!"
-            )
-            sys.exit()
+        # if (coord_type == "cart") and not (coord_kwargs is None or coord_kwargs == {}):
+        #     print(
+        #         "coord_type is set to 'cart' but coord_kwargs were given. "
+        #         "This is probably not intended. Exiting!"
+        #     )
+        #     sys.exit()
 
         # Coordinate systems are handled below
         coord_class = self.coord_types[self.coord_type]

--- a/pysisyphus/calculators/CFOUR.py
+++ b/pysisyphus/calculators/CFOUR.py
@@ -115,6 +115,9 @@ class CFOUR(Calculator):
         return results
 
     def rotate_gradient(self, text, gradient):
+        ## Following http://nghiaho.com/?page_id=671
+        ## Permalink: https://web.archive.org/web/20230128004529/http://nghiaho.com/?page_id=671
+
         cfour_coords_3d = self.read_geom(text)
         pysis_coords_3d = np.reshape(self.input_coords, (-1,3))
 
@@ -168,3 +171,6 @@ class CFOUR(Calculator):
         inp = self.prepare_input(atoms, coords, calc_type)
         results = self.run(inp, calc=calc_type)
         return results
+
+    def __str__(self):
+        return f"CFOUR({self.name})"

--- a/pysisyphus/calculators/CFOUR.py
+++ b/pysisyphus/calculators/CFOUR.py
@@ -17,6 +17,20 @@ class CFOUR(Calculator):
             initden_file=None,
             **kwargs,
     ):
+        """CFOUR calculator.
+
+        Wrapper handling CFOUR ground state energy and gradient calculations.
+        Memory must be specified as a CFOUR keyword (not checked).
+
+        Parameters
+        ----------
+        cfour_input : dict
+            CFOUR keywords and values. Note: "on" must be encapsulated in quotes to avoid being translated to True by YAML.
+        keep_molden : bool, optional
+            Whether or not to keep ground state SCF orbitals for each geometry step.
+        initden_file: str, optional
+            Path to an input initden file for use as a guess SCF density.
+        """
         super().__init__(**kwargs)
 
         self.cfour_input = cfour_input

--- a/pysisyphus/calculators/CFOUR.py
+++ b/pysisyphus/calculators/CFOUR.py
@@ -62,8 +62,6 @@ class CFOUR(Calculator):
 
         *CFOUR(UNITS=BOHR
         COORDINATES=CARTESIAN
-        FIXGEOM=ON
-        SYM=OFF
         {grad_string}{cfour_keyword_string})
 
         """).format(xyz_string=xyz_string, grad_string=grad_string, cfour_keyword_string=cfour_keyword_string)
@@ -107,15 +105,66 @@ class CFOUR(Calculator):
             if not mobj:
                 continue
             gradient.append(mobj.groups())
-        gradient = np.array(gradient, dtype=float).flatten()
+        gradient = np.array(gradient, dtype=float)
+        gradient_rotated = self.rotate_gradient(text, gradient).flatten()
 
         energy = self.parse_energy(path)
         results["energy"] = energy
-        results["forces"] = -gradient
+        results["forces"] = -gradient_rotated
 
         return results
 
+    def rotate_gradient(self, text, gradient):
+        cfour_coords_3d = self.read_geom(text)
+        pysis_coords_3d = np.reshape(self.input_coords, (-1,3))
+
+        cfour_centroid = self.calc_centroid(cfour_coords_3d)
+        pysis_centroid = self.calc_centroid(pysis_coords_3d)
+
+        rot_matrix = self.calc_rot_matrix(cfour_coords_3d, pysis_coords_3d, cfour_centroid, pysis_centroid)
+        t = self.calc_translation(rot_matrix, cfour_centroid, pysis_centroid)
+
+        return (gradient @ rot_matrix.T) + t
+
+    def read_geom(self, text):
+        regex = r"Coordinates used in calculation \(QCOMP\)(.+)Interatomic distance matrix"
+        floats =  [self.float_regex for i in range(3)]
+        line_regex = r"\s*[A-Z]+\s*\d+\s*" + r"\s*".join(floats) ## Element symbol, atomic number, then x, y, z in bohr
+
+        mobj = re.search(regex, text, re.DOTALL)
+        geom = list()
+        for line in mobj.groups()[0].split("\n"):
+            mobj = re.match(line_regex, line.strip())
+            if not mobj:
+                continue
+            geom.append(mobj.groups())
+        geom_3d = np.array(geom, dtype=float)
+
+        return geom_3d
+
+    def calc_centroid(self, coords_3d):
+        centroid = np.sum(coords_3d, axis=0)/coords_3d.shape[0]
+        return centroid
+
+    def calc_rot_matrix(self, cfour_coords_3d, pysis_coords_3d, cfour_centroid, pysis_centroid):
+        H = (cfour_coords_3d - cfour_centroid).T @ (pysis_coords_3d - pysis_centroid)
+        assert H.shape == (3,3)
+        U, S, V = np.linalg.svd(H)
+        R = V @ U.T
+
+        ## Cover corner case
+        if np.linalg.det(R) < 0:
+            U, S, V = np.linalg.svd(R)
+            V[:,2] = V[:,2]*-1
+            R = V @ U.T
+
+        return R
+
+    def calc_translation(self, rotation_matrix, cfour_centroid, pysis_centroid):
+        return pysis_centroid - rotation_matrix @ cfour_centroid
+
     def run_calculation(self, atoms, coords, calc_type):
+        self.input_coords = coords  ## For use later to rotate CFOUR gradient to the pysisyphus frame
         inp = self.prepare_input(atoms, coords, calc_type)
         results = self.run(inp, calc=calc_type)
         return results

--- a/pysisyphus/calculators/CFOUR.py
+++ b/pysisyphus/calculators/CFOUR.py
@@ -14,6 +14,7 @@ class CFOUR(Calculator):
             self,
             cfour_input,
             keep_molden=True,
+            initden_file=None,
             **kwargs,
     ):
         super().__init__(**kwargs)
@@ -26,6 +27,8 @@ class CFOUR(Calculator):
         self.initden = None
         if keep_molden:
             self.to_keep = self.to_keep + ("MOLDEN*",)
+        if initden_file:
+            self.initden = initden_file
 
         self.base_cmd = self.get_cmd("cmd")
         self.parser_funcs = {

--- a/pysisyphus/calculators/CFOUR.py
+++ b/pysisyphus/calculators/CFOUR.py
@@ -1,0 +1,121 @@
+import re
+import shutil
+import textwrap
+
+import numpy as np
+
+from pysisyphus.calculators.Calculator import Calculator
+
+class CFOUR(Calculator):
+
+    conf_key = "cfour"
+
+    def __init__(
+            self,
+            cfour_input,
+            keep_molden=True,
+            **kwargs,
+    ):
+        super().__init__(**kwargs)
+
+        self.cfour_input = cfour_input
+
+        self.inp_fn = 'ZMAT'
+        self.out_fn = 'out.log'
+        self.to_keep = ("out.log", "density:__den.dat")
+        self.initden = None
+        if keep_molden:
+            self.to_keep = self.to_keep + ("MOLDEN*",)
+
+        self.base_cmd = self.get_cmd("cmd")
+        self.parser_funcs = {
+            "energy": self.parse_energy,
+            "grad": self.parse_gradient,
+        }
+
+        self.float_regex = r"([-]?\d+\.\d+)"  ## CFOUR doesn't use scientific notation for final energy or gradient.
+
+    def prepare(self, inp):
+        path = super().prepare(inp)
+        if self.initden:
+            shutil.copy(self.initden,f"{path}/initden.dat")
+        return path
+
+    def keep(self, path):
+        kept_fns = super().keep(path)
+        try:
+            self.initden = kept_fns["density"]
+        except KeyError:
+            self.log("den.dat not found!")
+            return
+
+    def prepare_input(self, atoms, coords, calc_type):
+        xyz_string = self.prepare_coords(atoms, coords, angstrom=False)
+        cfour_keyword_string = '\n'.join(f"{key.upper()}={str(value).upper()}" for key, value in self.cfour_input.items())
+        grad_string = "DERIV_LEVEL=1\n" if calc_type == "grad" else ""
+
+        ### Note: CFOUR abhors blank lines between keywords. Make sure no extra whitespace is added between keyword lines.
+        ### First dedent, then format.
+        input_str = textwrap.dedent("""\
+        CFOUR calculation
+        {xyz_string}
+
+        *CFOUR(UNITS=BOHR
+        COORDINATES=CARTESIAN
+        FIXGEOM=ON
+        SYM=OFF
+        {grad_string}{cfour_keyword_string})
+
+        """).format(xyz_string=xyz_string, grad_string=grad_string, cfour_keyword_string=cfour_keyword_string)
+
+        return input_str
+
+    def get_energy(self, atoms, coords):
+        return self.run_calculation(atoms, coords, "energy")
+
+    def get_forces(self, atoms, coords):
+        return self.run_calculation(atoms, coords, "grad")
+
+    def parse_energy(self, path):
+        energy_fn = path / self.out_fn
+        with open(energy_fn) as handle:
+            text = handle.read()
+
+        regex = "\s*The final electronic energy is\s*" + self.float_regex
+        mobj = re.search(regex, text, re.DOTALL)
+        energy = float(mobj.groups()[0])
+
+        return energy
+
+    def parse_gradient(self, path):
+        ## Adapted from OpenMolcas calculator
+        results = {}
+        gradient_fn = path / self.out_fn
+        with open(gradient_fn) as handle:
+            text = handle.read()
+
+        # Search for the block containing the gradient table
+        regex = "gradient from JOBARC(.+)--executable xjoda finished"
+        floats = [self.float_regex for i in range(3)]
+        line_regex = r"^\s*" + r"\s*".join(floats) + r"\s*$"  ## Nothing but floats on the gradient lines
+
+        mobj = re.search(regex, text, re.DOTALL)
+        gradient = list()
+        for line in mobj.groups()[0].split("\n"):
+            # Now look for the lines containing the gradient
+            mobj = re.match(line_regex, line.strip())
+            if not mobj:
+                continue
+            gradient.append(mobj.groups())
+        gradient = np.array(gradient, dtype=float).flatten()
+
+        energy = self.parse_energy(path)
+        results["energy"] = energy
+        results["forces"] = -gradient
+
+        return results
+
+    def run_calculation(self, atoms, coords, calc_type):
+        inp = self.prepare_input(atoms, coords, calc_type)
+        results = self.run(inp, calc=calc_type)
+        return results

--- a/pysisyphus/calculators/Calculator.py
+++ b/pysisyphus/calculators/Calculator.py
@@ -362,7 +362,7 @@ class Calculator:
         coord_str += "$end"
         return coord_str
 
-    def prepare_coords(self, atoms, coords):
+    def prepare_coords(self, atoms, coords, angstrom=True):
         """Get 3d coords in Angstrom.
 
         Reshape internal 1d coords to 3d and convert to Angstrom.
@@ -379,7 +379,9 @@ class Calculator:
         coords: np.array, 3d
             3D-array holding coordinates in Angstrom.
         """
-        coords = coords.reshape(-1, 3) * BOHR2ANG
+        coords = coords.reshape(-1, 3)
+        if angstrom:
+            coords = coords * BOHR2ANG
         coords = "\n".join(
             [
                 "{} {:10.08f} {:10.08f} {:10.08f}".format(a, *c)
@@ -388,7 +390,7 @@ class Calculator:
         )
         return coords
 
-    def prepare_xyz_string(self, atoms, coords):
+    def prepare_xyz_string(self, atoms, coords, angstrom=True):
         """Returns a xyz string in Angstrom.
 
         Parameters
@@ -404,7 +406,7 @@ class Calculator:
             Coordinates in .xyz format.
         """
 
-        return f"{len(atoms)}\n\n{self.prepare_coords(atoms, coords)}"
+        return f"{len(atoms)}\n\n{self.prepare_coords(atoms, coords, angstrom)}"
 
     def run(
         self,

--- a/pysisyphus/calculators/__init__.py
+++ b/pysisyphus/calculators/__init__.py
@@ -33,6 +33,7 @@ __all__ = [
     "Turbomole",
     "TransTorque",
     "XTB",
+    "CFOUR",
 ]
 
 

--- a/pysisyphus/calculators/__init__.py
+++ b/pysisyphus/calculators/__init__.py
@@ -69,6 +69,7 @@ from pysisyphus.calculators.TIP3P import TIP3P
 from pysisyphus.calculators.TransTorque import TransTorque
 from pysisyphus.calculators.Turbomole import Turbomole
 from pysisyphus.calculators.XTB import XTB
+from pysisyphus.calculators.CFOUR import CFOUR
 
 
 logger = logging.getLogger("dimer")

--- a/pysisyphus/helpers.py
+++ b/pysisyphus/helpers.py
@@ -51,11 +51,7 @@ def geom_from_xyz_file(xyz_fn, coord_type="cart", **coord_kwargs):
     kwargs.update(coord_kwargs)
     xyz_fn = str(xyz_fn)
     atoms, coords, comment = parse_xyz_file(xyz_fn, with_comment=True)
-    if 'bohr' in coord_kwargs:
-        bohr = coord_kwargs.pop('bohr')
-        if not bohr:
-            coords *= ANG2BOHR
-    else:
+    if 'bohr' not in comment.lower():
         coords *= ANG2BOHR
     geom = Geometry(
         atoms,

--- a/pysisyphus/helpers.py
+++ b/pysisyphus/helpers.py
@@ -51,7 +51,12 @@ def geom_from_xyz_file(xyz_fn, coord_type="cart", **coord_kwargs):
     kwargs.update(coord_kwargs)
     xyz_fn = str(xyz_fn)
     atoms, coords, comment = parse_xyz_file(xyz_fn, with_comment=True)
-    coords *= ANG2BOHR
+    if 'bohr' in coord_kwargs:
+        bohr = coord_kwargs.pop('bohr')
+        if not bohr:
+            coords *= ANG2BOHR
+    else:
+        coords *= ANG2BOHR
     geom = Geometry(
         atoms,
         coords.flatten(),

--- a/pysisyphus/run.py
+++ b/pysisyphus/run.py
@@ -98,6 +98,7 @@ CALC_DICT = {
     "remote": Remote,
     "turbomole": Turbomole,
     "xtb": XTB,
+    "cfour": CFOUR,
 }
 
 try:


### PR DESCRIPTION
Hello,

This pull request should add support for CFOUR as a calculator. It handles some of the thornier issues of CFOUR automatically rotating the input geometry when dealing with symmetric structures.

As an aid in working with CFOUR, this also allows for reading of XYZ files in bohr (akin to OpenMolcas), where if the string "bohr" appears in the comment line, the XYZ file is interpreted in bohr.