### PR TITLE
nix: add turbomole and orca checks

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -105,6 +105,11 @@
         }) // {
       overlays.default = import ./nix/overlay.nix;
 
-      hydraJobs = self.checks;
+      hydraJobs = self.checks // {
+        x86_64-linux = {
+          pysisyphusTurbomole = self.packages.x86_64-linux.pysisyphusTurbomole;
+          pysisyphusOrca = self.packages.x86_64-linux.pysisyphusOrca;
+        };
+      };
     };
 }


### PR DESCRIPTION
Enables ORCA and Turbomole for the Hydra CI, see https://hydra.ipc3.uni-jena.de/eval/233

Provides better caching in university network and better error tracking for seldomly executed tests.