### PR TITLE
Add Geodesic interpolation

### DIFF
--- a/.github/workflows/pythonapp.yml
+++ b/.github/workflows/pythonapp.yml
@@ -57,6 +57,9 @@ jobs:
     - name: Install thermoanalysis
       run: |
         pip install git+https://github.com/eljost/thermoanalysis.git
+    - name: Install geodesic-interpolate
+      run: |
+        pip install git+https://github.com/virtualzx-nad/geodesic-interpolate.git
     - name: Test with pytest
       run: >
         pytest -v

--- a/pysisyphus/interpolate/Geodesic.py
+++ b/pysisyphus/interpolate/Geodesic.py
@@ -1,0 +1,71 @@
+import numpy as np
+
+from pysisyphus.Geometry import Geometry
+from pysisyphus.interpolate.Interpolator import Interpolator
+from pysisyphus.constants import BOHR2ANG
+
+can_geodesic = False
+try:
+    from geodesic_interpolate.interpolation import redistribute
+    from geodesic_interpolate.geodesic import Geodesic as Geo
+except ImportError:
+    can_geodesic = False
+
+
+class Geodesic(Interpolator):
+
+    def __init__(
+        self, *args, align=False, tol=2e-3, scaling=1.7, dist_cutoff=3.0,
+        friction=1e-2, maxiter=15, microiter=20, **kwargs
+        ):
+        """Geodesic Interpolation for Reaction Pathways.
+
+        Reference: https://doi.org/10.1063/1.5090303
+
+        Parameters
+        ----------
+        align : bool, optional
+            Whether to align geometries, by default False
+        tol : float, optional
+            Convergence tolerance, by default 2e-3
+        scaling : float, optional
+            Exponential parameter for morse potential, by default 1.7
+        dist_cutoff : float, optional
+            Cut-off value for the distance between a pair of atoms
+            to be included in the coordinate system, by default 3.0
+        friction : float, optional
+            Size of friction term used to prevent very large
+            change of geometry, by default 1e-2
+        maxiter : int, optional
+            Maximum number of minimization iterations, by default 15
+        microiter : int, optional
+            Maximum number of micro iterations for
+            sweeping algorithm, by default 20
+        """
+        super().__init__(*args, align=align, **kwargs)
+        self.tol = tol
+        self.scaling = scaling
+        self.dist_cutoff = dist_cutoff
+        self.friction = friction
+        self.maxiter = maxiter
+        self.microiter = microiter
+
+    def interpolate(self, initial_geom, final_geom, **kwargs):
+        if not can_geodesic:
+            raise ModuleNotFoundError(
+                "Geodesic interpolation requires the geodesic_interpolate package."
+            )
+        coords3d = np.array((initial_geom.coords3d, final_geom.coords3d))
+        coords3d *= BOHR2ANG
+
+        nimages = 2 + self.between
+        raw = redistribute(self.atoms, coords3d, nimages, tol=self.tol * 5)
+
+        smoother = Geo(self.atoms, raw, self.scaling, threshold=self.dist_cutoff, friction=self.friction)
+        if len(self.atoms) > 35:
+            path = smoother.sweep(tol=self.tol, max_iter=self.maxiter, micro_iter=self.microiter)
+        else:
+            path = smoother.smooth(tol=self.tol, max_iter=self.maxiter)
+        path /= BOHR2ANG
+        interpolated_geoms = [Geometry(self.atoms, coords) for coords in path]
+        return interpolated_geoms[1:-1]

--- a/pysisyphus/interpolate/Geodesic.py
+++ b/pysisyphus/interpolate/Geodesic.py
@@ -1,26 +1,40 @@
+# [1] https://doi.org/10.1063/1.5090303
+#     Geodesic interpolation for reaction pathways
+#     Zhu, Thompson, Martinez, 2019
+
 import numpy as np
 
 from pysisyphus.Geometry import Geometry
 from pysisyphus.interpolate.Interpolator import Interpolator
 from pysisyphus.constants import BOHR2ANG
 
-can_geodesic = False
 try:
     from geodesic_interpolate.interpolation import redistribute
     from geodesic_interpolate.geodesic import Geodesic as Geo
+
+    can_geodesic = True
 except ImportError:
     can_geodesic = False
 
 
 class Geodesic(Interpolator):
-
     def __init__(
-        self, *args, align=False, tol=2e-3, scaling=1.7, dist_cutoff=3.0,
-        friction=1e-2, maxiter=15, microiter=20, **kwargs
-        ):
+        self,
+        *args,
+        align: bool = False,
+        tol: float = 2e-3,
+        scaling: float = 1.7,
+        dist_cutoff: float = 3.0,
+        friction: float = 1e-2,
+        maxiter: int = 15,
+        microiter: int = 20,
+        **kwargs,
+    ):
         """Geodesic Interpolation for Reaction Pathways.
 
-        Reference: https://doi.org/10.1063/1.5090303
+        Requires the 'geodesic-interpolate' package found at
+
+            https://github.com/virtualzx-nad/geodesic-interpolate.git
 
         Parameters
         ----------
@@ -61,9 +75,17 @@ class Geodesic(Interpolator):
         nimages = 2 + self.between
         raw = redistribute(self.atoms, coords3d, nimages, tol=self.tol * 5)
 
-        smoother = Geo(self.atoms, raw, self.scaling, threshold=self.dist_cutoff, friction=self.friction)
+        smoother = Geo(
+            self.atoms,
+            raw,
+            self.scaling,
+            threshold=self.dist_cutoff,
+            friction=self.friction,
+        )
         if len(self.atoms) > 35:
-            path = smoother.sweep(tol=self.tol, max_iter=self.maxiter, micro_iter=self.microiter)
+            path = smoother.sweep(
+                tol=self.tol, max_iter=self.maxiter, micro_iter=self.microiter
+            )
         else:
             path = smoother.smooth(tol=self.tol, max_iter=self.maxiter)
         path /= BOHR2ANG

--- a/pysisyphus/interpolate/__init__.py
+++ b/pysisyphus/interpolate/__init__.py
@@ -3,6 +3,7 @@ __all__ = [
     "IDPP",
     "LST",
     "Redund",
+    "Geodesic"
 ]
 
 from pysisyphus.interpolate.helpers import interpolate, interpolate_all

--- a/pysisyphus/interpolate/helpers.py
+++ b/pysisyphus/interpolate/helpers.py
@@ -1,4 +1,4 @@
-from pysisyphus.interpolate import IDPP, LST, Interpolator, Redund
+from pysisyphus.interpolate import IDPP, LST, Interpolator, Redund, Geodesic
 
 
 INTERPOLATE = {
@@ -6,6 +6,7 @@ INTERPOLATE = {
     "lst": LST.LST,
     "redund": Redund.Redund,
     "linear": Interpolator.Interpolator,
+    "geodesic": Geodesic.Geodesic,
 }
 
 

--- a/pysisyphus/testing.py
+++ b/pysisyphus/testing.py
@@ -30,6 +30,7 @@ IMPORT_DICT = {
     "thermoanalysis": "thermoanalysis",
     "pyxtb": "xtb.interface",
     "obabel": "openbabel.openbabel",
+    "geodesic": "geodesic_interpolate",
 }
 
 
@@ -48,9 +49,8 @@ def module_available(calculator):
 
 
 class DummyMark:
-
     def __init__(self, available):
-        self.args = (available, )
+        self.args = (available,)
 
 
 def using(calculator, set_pytest_mark=True):

--- a/pysisyphus/trj.py
+++ b/pysisyphus/trj.py
@@ -29,6 +29,7 @@ INTERPOLATE = {
     "lst": LST.LST,
     "linear": Interpolator.Interpolator,
     "redund": Redund.Redund,
+    "geodesic": Geodesic.Geodesic,
 }
 
 
@@ -100,7 +101,7 @@ def parse_args(args):
         "--hsmerge",
         action="store_true",
         help="Merge two input geometries into one, while avoiding overlapping atoms "
-        "via hardsphere-optimization."
+        "via hardsphere-optimization.",
     )
     action_group.add_argument(
         "--join",
@@ -173,6 +174,11 @@ def parse_args(args):
     )
     interpolate_group.add_argument(
         "--redund", action="store_true", help="Interpolate in internal coordinates."
+    )
+    interpolate_group.add_argument(
+        "--geodesic",
+        action="store_true",
+        help="Geodesic interpolation. Requires the geodesic-interpolate package.",
     )
     parser.add_argument(
         "--extrapolate",
@@ -492,7 +498,9 @@ def append(geoms):
 def hardsphere_merge(geoms):
     assert len(geoms) == 2
     union = hardsphere_merge_driver(*geoms)
-    return [union, ]
+    return [
+        union,
+    ]
 
 
 def match(ref_geom, geom_to_match):
@@ -693,6 +701,8 @@ def run():
         interpol_type = "lst"
     elif args.redund:
         interpol_type = "redund"
+    elif args.geodesic:
+        interpol_type = "geodesic"
     elif args.between:
         interpol_type = "linear"
     else:

--- a/tests/test_interpolate/test_interpolate.py
+++ b/tests/test_interpolate/test_interpolate.py
@@ -6,6 +6,7 @@ from pysisyphus.interpolate.Interpolator import Interpolator
 from pysisyphus.interpolate.LST import LST
 from pysisyphus.interpolate.IDPP import IDPP
 from pysisyphus.interpolate.Redund import Redund
+from pysisyphus.interpolate.Geodesic import Geodesic
 
 
 def test_idpp():
@@ -27,6 +28,7 @@ def test_idpp():
         LST,
         IDPP,
         Redund,
+        Geodesic,
     ]
 )
 def test_ala_dipeptide_interpol(interpol_cls):

--- a/tests/test_interpolate/test_interpolate.py
+++ b/tests/test_interpolate/test_interpolate.py
@@ -1,12 +1,13 @@
 import pytest
 
-from pysisyphus.xyzloader import write_geoms_to_trj
+# from pysisyphus.xyzloader import write_geoms_to_trj
 from pysisyphus.helpers import geom_loader
 from pysisyphus.interpolate.Interpolator import Interpolator
 from pysisyphus.interpolate.LST import LST
 from pysisyphus.interpolate.IDPP import IDPP
 from pysisyphus.interpolate.Redund import Redund
 from pysisyphus.interpolate.Geodesic import Geodesic
+from pysisyphus.testing import using
 
 
 def test_idpp():
@@ -28,8 +29,8 @@ def test_idpp():
         LST,
         IDPP,
         Redund,
-        Geodesic,
-    ]
+        pytest.param(Geodesic, marks=using("geodesic")),
+    ],
 )
 def test_ala_dipeptide_interpol(interpol_cls):
     initial = geom_loader("lib:dipeptide_init.xyz")


### PR DESCRIPTION
This PR adds the geodesic interpolation for reaction pathways (https://doi.org/10.1063/1.5090303) to `interpolate`.

The only strange thing I noticed is that the `pytest` session seems to disable threading for `scipy`, such that the runtime is much slower on `pytest` than when running the `geodesic_interpolate` command manually from the command line.... not so important though.