### PR TITLE
nix updates

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -51,7 +51,7 @@
     },
     "flake-utils_3": {
       "inputs": {
-        "systems": "systems_2"
+        "systems": "systems_3"
       },
       "locked": {
         "lastModified": 1726560853,
@@ -69,7 +69,7 @@
     },
     "flake-utils_4": {
       "inputs": {
-        "systems": "systems_3"
+        "systems": "systems_4"
       },
       "locked": {
         "lastModified": 1710146030,
@@ -87,7 +87,7 @@
     },
     "flake-utils_5": {
       "inputs": {
-        "systems": "systems_4"
+        "systems": "systems_5"
       },
       "locked": {
         "lastModified": 1710146030,
@@ -103,20 +103,42 @@
         "type": "github"
       }
     },
-    "nix-bundle": {
+    "flake-utils_6": {
       "inputs": {
-        "nixpkgs": "nixpkgs"
+        "systems": "systems_6"
       },
       "locked": {
-        "lastModified": 1626704917,
-        "narHash": "sha256-cJ73kxY5ZCPWQeQZyCSdvkBqjqJkU5wgETBNaXfqF18=",
-        "owner": "matthewbauer",
-        "repo": "nix-bundle",
-        "rev": "223f4ffc4179aa318c34dc873a08cb00090db829",
+        "lastModified": 1726560853,
+        "narHash": "sha256-X6rJYSESBVr3hBoH0WbKE5KvhPU5bloyZ2L4K60/fPQ=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "c1dfcf08411b08f6b8615f7d8971a2bfa81d5e8a",
         "type": "github"
       },
       "original": {
-        "owner": "matthewbauer",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nix-bundle": {
+      "inputs": {
+        "nixpkgs": [
+          "nixBundlers",
+          "nixpkgs"
+        ],
+        "utils": "utils"
+      },
+      "locked": {
+        "lastModified": 1729095141,
+        "narHash": "sha256-2AXV3I8D/I3UkQY797j/fSKrIwbUpTVZ82s2O/ErtVM=",
+        "owner": "nix-community",
+        "repo": "nix-bundle",
+        "rev": "4f6330b20767744a4c28788e3cdb05e02d096cd8",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
         "repo": "nix-bundle",
         "type": "github"
       }
@@ -124,7 +146,7 @@
     "nix-utils": {
       "inputs": {
         "flake-utils": "flake-utils_2",
-        "nixpkgs": "nixpkgs_2"
+        "nixpkgs": "nixpkgs"
       },
       "locked": {
         "lastModified": 1632973430,
@@ -144,14 +166,14 @@
       "inputs": {
         "nix-bundle": "nix-bundle",
         "nix-utils": "nix-utils",
-        "nixpkgs": "nixpkgs_3"
+        "nixpkgs": "nixpkgs_2"
       },
       "locked": {
-        "lastModified": 1696517060,
-        "narHash": "sha256-V296JCORatNg44vQnNCkZASOmElY8NFT15OQ45a1ACQ=",
+        "lastModified": 1730753393,
+        "narHash": "sha256-HqV1S2idL29QpW4atCEd0qf8LUCmmTG9RRCPtEwoufw=",
         "owner": "NixOS",
         "repo": "bundlers",
-        "rev": "00762a03a3d862a2ca6272a21fdc50bda5d36c42",
+        "rev": "4dd1b979551b11faeae47e6599d71cd415d21bee",
         "type": "github"
       },
       "original": {
@@ -162,21 +184,6 @@
       }
     },
     "nixpkgs": {
-      "locked": {
-        "lastModified": 1620055814,
-        "narHash": "sha256-8LEHoYSJiL901bTMVatq+rf8y7QtWuZhwwpKE2fyaRY=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "1db42b7fe3878f3f5f7a4f2dc210772fd080e205",
-        "type": "github"
-      },
-      "original": {
-        "id": "nixpkgs",
-        "ref": "nixos-20.03-small",
-        "type": "indirect"
-      }
-    },
-    "nixpkgs_2": {
       "locked": {
         "lastModified": 1629252929,
         "narHash": "sha256-Aj20gmGBs8TG7pyaQqgbsqAQ6cB+TVuL18Pk3DPBxcQ=",
@@ -191,20 +198,23 @@
         "type": "github"
       }
     },
-    "nixpkgs_3": {
+    "nixpkgs_2": {
       "locked": {
-        "lastModified": 1634782485,
-        "narHash": "sha256-psfh4OQSokGXG0lpq3zKFbhOo3QfoeudRcaUnwMRkQo=",
-        "path": "/nix/store/p53cz6rh27q40g9i0q98k3vfrz6lm12w-source",
-        "rev": "34ad3ffe08adfca17fcb4e4a47bb5f3b113687be",
-        "type": "path"
+        "lastModified": 1728492678,
+        "narHash": "sha256-9UTxR8eukdg+XZeHgxW5hQA9fIKHsKCdOIUycTryeVw=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "5633bcff0c6162b9e4b5f1264264611e950c8ec7",
+        "type": "github"
       },
       "original": {
-        "id": "nixpkgs",
-        "type": "indirect"
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
       }
     },
-    "nixpkgs_4": {
+    "nixpkgs_3": {
       "locked": {
         "lastModified": 1727777050,
         "narHash": "sha256-5jw7zwOcWOpxTO6NCzmFZfq0klNGA+ktw+Yb3n35eUQ=",
@@ -220,13 +230,29 @@
         "type": "github"
       }
     },
-    "nixpkgs_5": {
+    "nixpkgs_4": {
       "locked": {
         "lastModified": 1724748588,
         "narHash": "sha256-NlpGA4+AIf1dKNq76ps90rxowlFXUsV9x7vK/mN37JM=",
         "owner": "NixOS",
         "repo": "nixpkgs",
         "rev": "a6292e34000dc93d43bccf78338770c1c5ec8a99",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_5": {
+      "locked": {
+        "lastModified": 1728472043,
+        "narHash": "sha256-+fUCZ7C34cp+bY5E9Hw4biRyI+IINVsO+sXFCieWkZA=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "4fa56ac6d86a213b556d4db9b1cb43a51b3e40ec",
         "type": "github"
       },
       "original": {
@@ -238,11 +264,11 @@
     },
     "nixpkgs_6": {
       "locked": {
-        "lastModified": 1727716680,
-        "narHash": "sha256-uMVkVHL4r3QmlZ1JM+UoJwxqa46cgHnIfqGzVlw5ca4=",
+        "lastModified": 1724748588,
+        "narHash": "sha256-NlpGA4+AIf1dKNq76ps90rxowlFXUsV9x7vK/mN37JM=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "b5b22b42c0d10c7d2463e90a546c394711e3a724",
+        "rev": "a6292e34000dc93d43bccf78338770c1c5ec8a99",
         "type": "github"
       },
       "original": {
@@ -254,11 +280,11 @@
     },
     "nixpkgs_7": {
       "locked": {
-        "lastModified": 1724748588,
-        "narHash": "sha256-NlpGA4+AIf1dKNq76ps90rxowlFXUsV9x7vK/mN37JM=",
+        "lastModified": 1728472043,
+        "narHash": "sha256-+fUCZ7C34cp+bY5E9Hw4biRyI+IINVsO+sXFCieWkZA=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "a6292e34000dc93d43bccf78338770c1c5ec8a99",
+        "rev": "4fa56ac6d86a213b556d4db9b1cb43a51b3e40ec",
         "type": "github"
       },
       "original": {
@@ -271,7 +297,7 @@
     "pysisyphus-addons": {
       "inputs": {
         "flake-utils": "flake-utils_3",
-        "nixpkgs": "nixpkgs_4",
+        "nixpkgs": "nixpkgs_3",
         "sympleints": "sympleints"
       },
       "locked": {
@@ -290,19 +316,37 @@
     },
     "qchem": {
       "inputs": {
-        "nixpkgs": "nixpkgs_6"
+        "nixpkgs": "nixpkgs_5"
       },
       "locked": {
-        "lastModified": 1727769626,
-        "narHash": "sha256-BLJ4XjV4Tm4RaQLYmSgrcDEcGOh56u8cZzAaFe7Fsmw=",
+        "lastModified": 1729862339,
+        "narHash": "sha256-681g/vv+ZNnhT/5U1dJvORk4vnsrbgtGUumhMuO0meM=",
         "owner": "nix-qchem",
         "repo": "nixos-qchem",
-        "rev": "99b74e661fe6dfc4c276850bdd4e62f7bb47a9dc",
+        "rev": "6b4144e50a901785dee3271763a3d23a1079a9f1",
         "type": "github"
       },
       "original": {
         "owner": "nix-qchem",
         "ref": "master",
+        "repo": "nixos-qchem",
+        "type": "github"
+      }
+    },
+    "qchem_2": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_7"
+      },
+      "locked": {
+        "lastModified": 1729514893,
+        "narHash": "sha256-2uC4QJCcnS37UJ1npGv+0N/77Qx9ylkQhDplGTMq9EU=",
+        "owner": "nix-qchem",
+        "repo": "nixos-qchem",
+        "rev": "64d3989e6be4a7f34bdbf10cc5b71009aa155071",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-qchem",
         "repo": "nixos-qchem",
         "type": "github"
       }
@@ -314,13 +358,14 @@
         "nixBundlers": "nixBundlers",
         "pysisyphus-addons": "pysisyphus-addons",
         "qchem": "qchem",
-        "sympleints": "sympleints_2"
+        "sympleints": "sympleints_2",
+        "thermoanalysis": "thermoanalysis"
       }
     },
     "sympleints": {
       "inputs": {
         "flake-utils": "flake-utils_4",
-        "nixpkgs": "nixpkgs_5"
+        "nixpkgs": "nixpkgs_4"
       },
       "locked": {
         "lastModified": 1727857764,
@@ -339,7 +384,7 @@
     "sympleints_2": {
       "inputs": {
         "flake-utils": "flake-utils_5",
-        "nixpkgs": "nixpkgs_7"
+        "nixpkgs": "nixpkgs_6"
       },
       "locked": {
         "lastModified": 1727857764,
@@ -412,6 +457,73 @@
       "original": {
         "owner": "nix-systems",
         "repo": "default",
+        "type": "github"
+      }
+    },
+    "systems_5": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    },
+    "systems_6": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    },
+    "thermoanalysis": {
+      "inputs": {
+        "flake-utils": "flake-utils_6",
+        "qchem": "qchem_2"
+      },
+      "locked": {
+        "lastModified": 1729518383,
+        "narHash": "sha256-5r2AYQMhNQW3rkHswbdETS8r1Z8xX7ejFNQoAXGzCDY=",
+        "owner": "eljost",
+        "repo": "thermoanalysis",
+        "rev": "b3e5d8673f900500d5f35bf5fb9e48c33456272b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "eljost",
+        "repo": "thermoanalysis",
+        "type": "github"
+      }
+    },
+    "utils": {
+      "inputs": {
+        "systems": "systems_2"
+      },
+      "locked": {
+        "lastModified": 1726560853,
+        "narHash": "sha256-X6rJYSESBVr3hBoH0WbKE5KvhPU5bloyZ2L4K60/fPQ=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "c1dfcf08411b08f6b8615f7d8971a2bfa81d5e8a",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
         "type": "github"
       }
     }

--- a/flake.lock
+++ b/flake.lock
@@ -21,11 +21,11 @@
         "systems": "systems"
       },
       "locked": {
-        "lastModified": 1710146030,
-        "narHash": "sha256-SZ5L6eA7HJ/nmkzGG7/ISclqe6oZdOZTNoesiInkXPQ=",
+        "lastModified": 1726560853,
+        "narHash": "sha256-X6rJYSESBVr3hBoH0WbKE5KvhPU5bloyZ2L4K60/fPQ=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "b1d9ab70662946ef0850d488da1c9019f3a9752a",
+        "rev": "c1dfcf08411b08f6b8615f7d8971a2bfa81d5e8a",
         "type": "github"
       },
       "original": {
@@ -41,6 +41,60 @@
         "owner": "numtide",
         "repo": "flake-utils",
         "rev": "f7e004a55b120c02ecb6219596820fcd32ca8772",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "flake-utils_3": {
+      "inputs": {
+        "systems": "systems_2"
+      },
+      "locked": {
+        "lastModified": 1726560853,
+        "narHash": "sha256-X6rJYSESBVr3hBoH0WbKE5KvhPU5bloyZ2L4K60/fPQ=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "c1dfcf08411b08f6b8615f7d8971a2bfa81d5e8a",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "flake-utils_4": {
+      "inputs": {
+        "systems": "systems_3"
+      },
+      "locked": {
+        "lastModified": 1710146030,
+        "narHash": "sha256-SZ5L6eA7HJ/nmkzGG7/ISclqe6oZdOZTNoesiInkXPQ=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "b1d9ab70662946ef0850d488da1c9019f3a9752a",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "flake-utils_5": {
+      "inputs": {
+        "systems": "systems_4"
+      },
+      "locked": {
+        "lastModified": 1710146030,
+        "narHash": "sha256-SZ5L6eA7HJ/nmkzGG7/ISclqe6oZdOZTNoesiInkXPQ=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "b1d9ab70662946ef0850d488da1c9019f3a9752a",
         "type": "github"
       },
       "original": {
@@ -152,11 +206,11 @@
     },
     "nixpkgs_4": {
       "locked": {
-        "lastModified": 1709780214,
-        "narHash": "sha256-p4iDKdveHMhfGAlpxmkCtfQO3WRzmlD11aIcThwPqhk=",
+        "lastModified": 1727777050,
+        "narHash": "sha256-5jw7zwOcWOpxTO6NCzmFZfq0klNGA+ktw+Yb3n35eUQ=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "f945939fd679284d736112d3d5410eb867f3b31c",
+        "rev": "d78d09350ac7dfe503cf48cbc59764aef4157b9a",
         "type": "github"
       },
       "original": {
@@ -166,16 +220,84 @@
         "type": "github"
       }
     },
-    "qchem": {
+    "nixpkgs_5": {
+      "locked": {
+        "lastModified": 1724748588,
+        "narHash": "sha256-NlpGA4+AIf1dKNq76ps90rxowlFXUsV9x7vK/mN37JM=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "a6292e34000dc93d43bccf78338770c1c5ec8a99",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_6": {
+      "locked": {
+        "lastModified": 1727716680,
+        "narHash": "sha256-uMVkVHL4r3QmlZ1JM+UoJwxqa46cgHnIfqGzVlw5ca4=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "b5b22b42c0d10c7d2463e90a546c394711e3a724",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_7": {
+      "locked": {
+        "lastModified": 1724748588,
+        "narHash": "sha256-NlpGA4+AIf1dKNq76ps90rxowlFXUsV9x7vK/mN37JM=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "a6292e34000dc93d43bccf78338770c1c5ec8a99",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "pysisyphus-addons": {
       "inputs": {
-        "nixpkgs": "nixpkgs_4"
+        "flake-utils": "flake-utils_3",
+        "nixpkgs": "nixpkgs_4",
+        "sympleints": "sympleints"
       },
       "locked": {
-        "lastModified": 1710238240,
-        "narHash": "sha256-HKbY7EOfbIf0nM2bf1HP7TEwnySNeIr0P5GxQrXhePc=",
+        "lastModified": 1727857962,
+        "narHash": "sha256-MwQJ+dW7qsEkZoDH0Zq6Dibb1JoimSK7NSPaWCFb7gM=",
+        "owner": "eljost",
+        "repo": "pysisyphus-addons",
+        "rev": "e4ff9817e9f48a68a7548700559fdffe925ee43d",
+        "type": "github"
+      },
+      "original": {
+        "owner": "eljost",
+        "repo": "pysisyphus-addons",
+        "type": "github"
+      }
+    },
+    "qchem": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_6"
+      },
+      "locked": {
+        "lastModified": 1727769626,
+        "narHash": "sha256-BLJ4XjV4Tm4RaQLYmSgrcDEcGOh56u8cZzAaFe7Fsmw=",
         "owner": "nix-qchem",
         "repo": "nixos-qchem",
-        "rev": "bda8e9ef66a315521575e26e71089209b13ed89a",
+        "rev": "99b74e661fe6dfc4c276850bdd4e62f7bb47a9dc",
         "type": "github"
       },
       "original": {
@@ -190,10 +312,95 @@
         "flake-compat": "flake-compat",
         "flake-utils": "flake-utils",
         "nixBundlers": "nixBundlers",
-        "qchem": "qchem"
+        "pysisyphus-addons": "pysisyphus-addons",
+        "qchem": "qchem",
+        "sympleints": "sympleints_2"
+      }
+    },
+    "sympleints": {
+      "inputs": {
+        "flake-utils": "flake-utils_4",
+        "nixpkgs": "nixpkgs_5"
+      },
+      "locked": {
+        "lastModified": 1727857764,
+        "narHash": "sha256-v/wJBb0b4P/jViiB1Uin0PelioQcm09MEFUazYW9uMo=",
+        "owner": "eljost",
+        "repo": "sympleints",
+        "rev": "fe51f170d6cef36d92806643fcbaa8b8d5fabc2d",
+        "type": "github"
+      },
+      "original": {
+        "owner": "eljost",
+        "repo": "sympleints",
+        "type": "github"
+      }
+    },
+    "sympleints_2": {
+      "inputs": {
+        "flake-utils": "flake-utils_5",
+        "nixpkgs": "nixpkgs_7"
+      },
+      "locked": {
+        "lastModified": 1727857764,
+        "narHash": "sha256-v/wJBb0b4P/jViiB1Uin0PelioQcm09MEFUazYW9uMo=",
+        "owner": "eljost",
+        "repo": "sympleints",
+        "rev": "fe51f170d6cef36d92806643fcbaa8b8d5fabc2d",
+        "type": "github"
+      },
+      "original": {
+        "owner": "eljost",
+        "repo": "sympleints",
+        "type": "github"
       }
     },
     "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    },
+    "systems_2": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    },
+    "systems_3": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    },
+    "systems_4": {
       "locked": {
         "lastModified": 1681028828,
         "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",

--- a/flake.lock
+++ b/flake.lock
@@ -3,11 +3,11 @@
     "flake-compat": {
       "flake": false,
       "locked": {
-        "lastModified": 1696426674,
-        "narHash": "sha256-kvjfFW7WAETZlt09AgDn1MrtKzP7t90Vf7vypd3OL1U=",
+        "lastModified": 1733328505,
+        "narHash": "sha256-NeCCThCEP3eCl2l/+27kNNK7QrwZB1IJCrXfrbv5oqU=",
         "owner": "edolstra",
         "repo": "flake-compat",
-        "rev": "0f9255e01c2351cc7d116c072cb317785dd33b33",
+        "rev": "ff81ac966bb2cae68946d5ed5fc4994f96d0ffec",
         "type": "github"
       },
       "original": {
@@ -21,11 +21,11 @@
         "systems": "systems"
       },
       "locked": {
-        "lastModified": 1726560853,
-        "narHash": "sha256-X6rJYSESBVr3hBoH0WbKE5KvhPU5bloyZ2L4K60/fPQ=",
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "c1dfcf08411b08f6b8615f7d8971a2bfa81d5e8a",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
         "type": "github"
       },
       "original": {
@@ -169,11 +169,11 @@
         "nixpkgs": "nixpkgs_2"
       },
       "locked": {
-        "lastModified": 1730753393,
-        "narHash": "sha256-HqV1S2idL29QpW4atCEd0qf8LUCmmTG9RRCPtEwoufw=",
+        "lastModified": 1730753475,
+        "narHash": "sha256-eQyHKjL/u8w/9WiLfLtFPzqX0swn4VPqZMJ5/kKd3wc=",
         "owner": "NixOS",
         "repo": "bundlers",
-        "rev": "4dd1b979551b11faeae47e6599d71cd415d21bee",
+        "rev": "e3ea69055b77cc2b17c6ce4067b7e3bb01871245",
         "type": "github"
       },
       "original": {
@@ -248,11 +248,11 @@
     },
     "nixpkgs_5": {
       "locked": {
-        "lastModified": 1728472043,
-        "narHash": "sha256-+fUCZ7C34cp+bY5E9Hw4biRyI+IINVsO+sXFCieWkZA=",
+        "lastModified": 1738678663,
+        "narHash": "sha256-uPdqVr8gN3oYYcueL/Rh7wM4Y8/D6p9IvRmoBf+uQa8=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "4fa56ac6d86a213b556d4db9b1cb43a51b3e40ec",
+        "rev": "00769b0532199db4e1bda59865f00f3a86232c75",
         "type": "github"
       },
       "original": {
@@ -319,11 +319,11 @@
         "nixpkgs": "nixpkgs_5"
       },
       "locked": {
-        "lastModified": 1729862339,
-        "narHash": "sha256-681g/vv+ZNnhT/5U1dJvORk4vnsrbgtGUumhMuO0meM=",
+        "lastModified": 1739200318,
+        "narHash": "sha256-ktQ1fC+cDXj4PrXmAb2t4qioGVORfQtGvJR5gTy/c0E=",
         "owner": "nix-qchem",
         "repo": "nixos-qchem",
-        "rev": "6b4144e50a901785dee3271763a3d23a1079a9f1",
+        "rev": "36e5292f5a49a985125ac9d9b79cca039c96780a",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -16,6 +16,8 @@
     pysisyphus-addons.url = "github:eljost/pysisyphus-addons";
 
     sympleints.url = "github:eljost/sympleints";
+
+    thermoanalysis.url = "github:eljost/thermoanalysis";
   };
 
   nixConfig = {
@@ -24,16 +26,17 @@
     extra-subtituters = [ "https://pysisyphus.cachix.org" ];
   };
 
-  outputs = { self, qchem, sympleints, pysisyphus-addons, flake-utils, nixBundlers, ... }:
+  outputs = { self, qchem, sympleints, pysisyphus-addons, thermoanalysis, flake-utils, nixBundlers, ... }:
     flake-utils.lib.eachSystem [ "x86_64-linux" ]
       (system:
         let
           pkgs = import qchem.inputs.nixpkgs {
             inherit system;
             overlays = [
+              qchem.overlays.default
+              thermoanalysis.overlays.default
               sympleints.overlays.default
               pysisyphus-addons.overlays.default
-              qchem.overlays.default
               (import ./nix/overlay.nix)
             ];
             config = {
@@ -82,7 +85,7 @@
           devShells.default =
             let
               pythonEnv = pkgs.python3.withPackages (p: with p;
-                [ pip ]
+                [ pip pytest ]
                 ++ p.pysisyphus.nativeBuildInputs
                 ++ p.pysisyphus.buildInputs
                 ++ p.pysisyphus.propagatedBuildInputs

--- a/flake.nix
+++ b/flake.nix
@@ -12,6 +12,10 @@
     flake-utils.url = "github:numtide/flake-utils";
 
     nixBundlers.url = "github:NixOS/bundlers/master";
+
+    pysisyphus-addons.url = "github:eljost/pysisyphus-addons";
+
+    sympleints.url = "github:eljost/sympleints";
   };
 
   nixConfig = {
@@ -20,13 +24,18 @@
     extra-subtituters = [ "https://pysisyphus.cachix.org" ];
   };
 
-  outputs = { self, qchem, flake-utils, nixBundlers, ... }:
+  outputs = { self, qchem, sympleints, pysisyphus-addons, flake-utils, nixBundlers, ... }:
     flake-utils.lib.eachSystem [ "x86_64-linux" ]
       (system:
         let
           pkgs = import qchem.inputs.nixpkgs {
             inherit system;
-            overlays = [ qchem.overlays.default (import ./nix/overlay.nix) ];
+            overlays = [
+              sympleints.overlays.default
+              pysisyphus-addons.overlays.default
+              qchem.overlays.default
+              (import ./nix/overlay.nix)
+            ];
             config = {
               allowUnfree = true;
               qchem-config = {

--- a/nix/overlay.nix
+++ b/nix/overlay.nix
@@ -1,17 +1,48 @@
 final: prev: {
   pysisyphus = prev.python3.pkgs.toPythonApplication final.python3.pkgs.pysisyphus;
 
+  qchem = prev.qchem // {
+    orca = prev.qchem.orca.overrideAttrs (oldAttrs: {
+      version = "5.0.4";
+
+      src = prev.requireFile {
+        name = "orca_5_0_4_linux_x86-64_shared_openmpi411.tar.xz";
+        sha256 = "sha256-xOpa6mDae8sYprcEJgkgb76yp2XG+pWMVonUULWIsDY=";
+        message = "Please add orca_5_0_4_linux_x86-64_shared_openmpi411.tar.xz to the nix store";
+      };
+
+      installPhase = ''
+        mkdir -p $out/bin $out/lib $out/share/doc/orca
+
+        cp autoci_* $out/bin
+        cp orca_* $out/bin
+        cp orca $out/bin
+        cp otool_* $out/bin
+
+        cp -r ORCACompoundMethods $out/bin/.
+
+        cp *.so.5 $out/lib/.
+
+        cp *.pdf $out/share/doc/orca
+
+        wrapProgram $out/bin/orca --prefix PATH : '${final.openmpi}/bin:${final.openssh}/bin'
+
+        ln -s ${final.qchem.xtb}/bin/xtb $out/bin/otool_xtb
+      '';
+    });
+  };
+
   python3 = prev.python3.override (old: {
     packageOverrides = prev.lib.composeExtensions (old.packageOverrides or (_: _: { })) (pfinal: pprev: {
-      pysisyphus = prev.qchem.python3.pkgs.callPackage ./pysisyphus.nix {
-        inherit (prev.qchem)
+      pysisyphus = pfinal.callPackage ./pysisyphus.nix {
+        inherit (final.qchem)
           multiwfn
           xtb
           molcas
           psi4
           wfoverlap
           nwchem
-          orca
+          orca # Requires ORCA 5.0 series
           turbomole
           gaussian
           cfour

--- a/nix/pysisyphus.nix
+++ b/nix/pysisyphus.nix
@@ -8,6 +8,7 @@
 , nix-gitignore
   # Python dependencies
 , pysisyphus-addons
+, thermoanalysis
 , setuptools-scm
 , autograd
 , dask
@@ -29,6 +30,7 @@
 , openbabel-bindings
 , pyscf
 , numba
+, optuna
   # Runtime dependencies
 , runtimeShell
 , jmol
@@ -112,7 +114,7 @@ let
 in
 buildPythonPackage rec {
   pname = "pysisyphus";
-  version = "0.8.0b0";
+  version = "1.0.0";
 
   build-system = [
     makeWrapper
@@ -121,6 +123,7 @@ buildPythonPackage rec {
 
   dependencies = [
     pysisyphus-addons
+    thermoanalysis
     autograd
     dask
     distributed
@@ -142,6 +145,7 @@ buildPythonPackage rec {
     openssh
     pyscf
     numba
+    optuna
   ] # Syscalls
   ++ lib.optional enableXtb xtb
   ++ lib.optional enableTblite tblite
@@ -188,6 +192,7 @@ buildPythonPackage rec {
         "hcn_neb_dimer_irc"
         "test_ci_opt[RFOptimizer-opt_kwargs1--78.2487951]" # Broken as of PySCF >= 2.3 as a DFT functional definition was changed
         "test_composite_oniom[lib:subst_effect/toluene_minus_H_b3lypG_631g.xyz-2-high_inds1--270.824806805671]" # Slight numerical deviations
+        "test_spectrum_ctnum"
       ];
     in
     [

--- a/nix/pysisyphus.nix
+++ b/nix/pysisyphus.nix
@@ -31,6 +31,8 @@
 , pyscf
 , numba
 , optuna
+, jax
+, jaxlib
   # Runtime dependencies
 , runtimeShell
 , jmol
@@ -146,6 +148,8 @@ buildPythonPackage rec {
     pyscf
     numba
     optuna
+    jax
+    jaxlib
   ] # Syscalls
   ++ lib.optional enableXtb xtb
   ++ lib.optional enableTblite tblite
@@ -193,7 +197,6 @@ buildPythonPackage rec {
         "test_ci_opt[RFOptimizer-opt_kwargs1--78.2487951]" # Broken as of PySCF >= 2.3 as a DFT functional definition was changed
         "test_composite_oniom[lib:subst_effect/toluene_minus_H_b3lypG_631g.xyz-2-high_inds1--270.824806805671]" # Slight numerical deviations
         "test_spectrum_ctnum"
-        "test_constrain_h2o_ofix"
       ];
     in
     [

--- a/nix/pysisyphus.nix
+++ b/nix/pysisyphus.nix
@@ -33,6 +33,7 @@
 , optuna
 , jax
 , jaxlib
+, networkx
   # Runtime dependencies
 , runtimeShell
 , jmol
@@ -150,6 +151,7 @@ buildPythonPackage rec {
     optuna
     jax
     jaxlib
+    networkx
   ] # Syscalls
   ++ lib.optional enableXtb xtb
   ++ lib.optional enableTblite tblite

--- a/nix/pysisyphus.nix
+++ b/nix/pysisyphus.nix
@@ -7,6 +7,7 @@
 , pytestCheckHook
 , nix-gitignore
   # Python dependencies
+, pysisyphus-addons
 , setuptools-scm
 , autograd
 , dask
@@ -25,9 +26,9 @@
 , psutils
 , qcengine
 , ase
-, xtb-python
 , openbabel-bindings
 , pyscf
+, numba
   # Runtime dependencies
 , runtimeShell
 , jmol
@@ -36,6 +37,8 @@
 , enableMultiwfn ? true
 , xtb
 , enableXtb ? true
+, tblite
+, enableTblite ? true
 , molcas
 , enableMolcas ? true
 , psi4
@@ -93,6 +96,7 @@ let
     ++ lib.optional enableJmol jmol
     ++ lib.optional enableMultiwfn multiwfn
     ++ lib.optional enableXtb xtb
+    ++ lib.optional enableTblite tblite
     ++ lib.optional enableMolcas molcas
     ++ lib.optional enablePsi4 psi4
     ++ lib.optional enableWfoverlap wfoverlap
@@ -110,13 +114,13 @@ buildPythonPackage rec {
   pname = "pysisyphus";
   version = "0.8.0b0";
 
-  nativeBuildInputs = [
+  build-system = [
     makeWrapper
     setuptools-scm
-    mpiCheckPhaseHook
   ];
 
-  propagatedBuildInputs = [
+  dependencies = [
+    pysisyphus-addons
     autograd
     dask
     distributed
@@ -137,9 +141,10 @@ buildPythonPackage rec {
     openbabel-bindings
     openssh
     pyscf
+    numba
   ] # Syscalls
-  ++ lib.optional enableXtb xtb-python
   ++ lib.optional enableXtb xtb
+  ++ lib.optional enableTblite tblite
   ++ lib.optional enableJmol jmol
   ++ lib.optional enableMultiwfn multiwfn
   ++ lib.optional enableMolcas molcas
@@ -160,7 +165,7 @@ buildPythonPackage rec {
 
   preBuild = "export SETUPTOOLS_SCM_PRETEND_VERSION=${version}";
 
-  checkInputs = [ openssh pytestCheckHook ];
+  checkInputs = [ openssh pytestCheckHook mpiCheckPhaseHook ];
 
   preCheck = ''
     export PYSISRC=${pysisrc}

--- a/nix/pysisyphus.nix
+++ b/nix/pysisyphus.nix
@@ -193,6 +193,7 @@ buildPythonPackage rec {
         "test_ci_opt[RFOptimizer-opt_kwargs1--78.2487951]" # Broken as of PySCF >= 2.3 as a DFT functional definition was changed
         "test_composite_oniom[lib:subst_effect/toluene_minus_H_b3lypG_631g.xyz-2-high_inds1--270.824806805671]" # Slight numerical deviations
         "test_spectrum_ctnum"
+        "test_constrain_h2o_ofix"
       ];
     in
     [

--- a/tests/test_composite/test_composite.py
+++ b/tests/test_composite/test_composite.py
@@ -32,7 +32,7 @@ def test_ch4_composite(this_dir):
         },
         "charge": 0,
         "mult": 1,
-        "pal": 6,
+        "pal": 2,
         "final": "ccsdt + mp2_high - mp2_low",
     }
     calc = Composite(**calc_kwargs)
@@ -62,7 +62,7 @@ def test_composite_run_dict(this_dir):
                 },
             },
             "final": "high - low",
-            "pal": 4,
+            "pal": 2,
         },
     }
     results = run_from_dict(run_dict)

--- a/tests/test_oniom/test_oniom.py
+++ b/tests/test_oniom/test_oniom.py
@@ -513,7 +513,7 @@ def test_oniom_microiters():
 )
 def test_composite_oniom(fn, mult, high_inds, ref_energy):
     charge = 0
-    pal = 6
+    pal = 2
     run_dict = {
         "geom": {
             "type": "cart",

--- a/tests/test_run/test_run.py
+++ b/tests/test_run/test_run.py
@@ -169,7 +169,9 @@ def test_run_irc_constrained_endopt(this_dir):
     feg, beg = results.end_geoms
     for end_geom in results.end_geoms:
         c3d = end_geom.coords3d
-        np.testing.assert_allclose(c3d[constrain_ind], ref_c3d[constrain_ind])
+        np.testing.assert_allclose(
+            c3d[constrain_ind], ref_c3d[constrain_ind], atol=1e-6
+        )
 
 
 @using("pyscf")


### PR DESCRIPTION
This Nix PR adds the compiled pysisyphus addons with sympleints, adds thermoanalysis module, the missing numba and optuna dependencies, and forces usage of ORCA 5.0.4 instead of the current 6.0.1 release.