### PR TITLE
Fix gradient rotation in CFOUR calculator

### DIFF
--- a/pysisyphus/calculators/CFOUR.py
+++ b/pysisyphus/calculators/CFOUR.py
@@ -87,14 +87,14 @@ def calc_rot_matrix(
 ):
     H = (source_coords_3d - source_centroid).T @ (target_coords_3d - target_centroid)
     assert H.shape == (3, 3)
-    U, S, V = np.linalg.svd(H)
-    R = V @ U.T
+    U, S, Vh = np.linalg.svd(H)
+    R = Vh.T @ U.T
 
     # Cover corner case
     if np.linalg.det(R) < 0:
-        U, S, V = np.linalg.svd(R)
-        V[:, 2] = V[:, 2] * -1
-        R = V @ U.T
+        U, S, Vh = np.linalg.svd(R)
+        Vh[2, :] = Vh[2, :] * -1
+        R = Vh.T @ U.T
 
     return R
 


### PR DESCRIPTION
I committed a bug some time ago in the rotation of the gradient between the CFOUR and pysisyphus coordinate frames. The numpy SVD function returns Vh, whereas the code originally assumed it returned V.

Not sure how this was working at all previously, to be honest.