### PR TITLE
COS frozen atoms sanity check

### DIFF
--- a/pysisyphus/cos/ChainOfStates.py
+++ b/pysisyphus/cos/ChainOfStates.py
@@ -51,6 +51,20 @@ class ChainOfStates:
     ):
         assert len(images) >= 2, "Need at least 2 images!"
         self.images = list(images)
+
+        if len(self.images[0].freeze_atoms) > 0:
+            # Check coherence of frozen positions
+            ref_coords = self.images[0].coords3d[self.images[0].freeze_atoms]
+            for image in self.images[1:]:
+                other_coords = image.coords3d[image.freeze_atoms]
+                diff = ref_coords - other_coords
+
+                # All frozen positions should be mappable to each other with a translation,
+                # so the 3D cartesian position differences should be identical.
+                ref = diff[0, :]
+                for pos in diff[1:, :]:
+                    assert np.allclose(ref, pos), "Frozen positions are not consistent between images!"
+
         self.fix_first = fix_first
         self.fix_last = fix_last
         self.align_fixed = align_fixed


### PR DESCRIPTION
This PR adds a simple sanity check to make sure that frozen atoms have consistent positions across images of COS calculations.

This can catch off-by-one errors in atom indices, for example. The current behaviour is that no error will be raised and the frozen atoms will abruptly switch between positions somewhere along the string. I don't see any case where that could be preferable, so I'm suggesting this small patch.

I haven't added any test since I wasn't sure how reference structures should be handled, but here is a simple case that should trigger an exception:
[cos_frozen_atoms_sanity_check_test.zip](https://github.com/user-attachments/files/21823034/cos_frozen_atoms_sanity_check_test.zip)
 